### PR TITLE
Separate DataModel type and Model modelType

### DIFF
--- a/mauro-domain/src/main/groovy/uk/ac/ox/softeng/mauro/domain/datamodel/DataModel.groovy
+++ b/mauro-domain/src/main/groovy/uk/ac/ox/softeng/mauro/domain/datamodel/DataModel.groovy
@@ -1,17 +1,18 @@
 package uk.ac.ox.softeng.mauro.domain.datamodel
 
 import com.fasterxml.jackson.annotation.JsonAlias
-import uk.ac.ox.softeng.mauro.domain.model.Model
-import uk.ac.ox.softeng.mauro.domain.model.ModelItem
-
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
 import groovy.transform.AutoClone
 import groovy.transform.CompileStatic
 import groovy.transform.MapConstructor
 import io.micronaut.core.annotation.Introspected
 import io.micronaut.data.annotation.MappedEntity
+import io.micronaut.data.annotation.MappedProperty
 import io.micronaut.data.annotation.Relation
 import jakarta.persistence.Transient
+import uk.ac.ox.softeng.mauro.domain.model.Model
+import uk.ac.ox.softeng.mauro.domain.model.ModelItem
 
 /**
  * A DataModel describes a data asset, or a data standard
@@ -42,6 +43,12 @@ class DataModel extends Model {
     @JsonIgnore
     Set<EnumerationValue> enumerationValues = []
 
+    @Transient
+    String modelType = domainType
+
+    @JsonProperty('type')
+    @MappedProperty('model_type')
+    String dataModelType = DataModelType.DATA_ASSET.label
 
     @Override
     @Transient
@@ -50,8 +57,8 @@ class DataModel extends Model {
         'dm'
     }
 
-    void setModelType(String modelType) {
-        modelType = DataModelType.values().find {it.label.toLowerCase() == modelType.toLowerCase()}?.label
+    void setDataModelType(String dataModelType) {
+        this.dataModelType = DataModelType.values().find {it.label.toLowerCase() == dataModelType.toLowerCase()}?.label
     }
 
 
@@ -132,9 +139,9 @@ class DataModel extends Model {
         build [:], closure
     }
 
-    String modelType(DataModelType dataModelType) {
-        this.modelType = dataModelType.label
-        this.modelType
+    String dataModelType(DataModelType dataModelType) {
+        this.dataModelType = dataModelType.label
+        this.dataModelType
     }
 
     DataType primitiveType(DataType primitiveType) {

--- a/mauro-domain/src/main/groovy/uk/ac/ox/softeng/mauro/domain/model/Model.groovy
+++ b/mauro-domain/src/main/groovy/uk/ac/ox/softeng/mauro/domain/model/Model.groovy
@@ -1,6 +1,6 @@
 package uk.ac.ox.softeng.mauro.domain.model
 
-import com.fasterxml.jackson.annotation.JsonAlias
+
 import com.fasterxml.jackson.annotation.JsonIgnore
 import groovy.transform.CompileStatic
 import groovy.transform.NamedParams
@@ -10,7 +10,6 @@ import jakarta.persistence.Transient
 import uk.ac.ox.softeng.mauro.domain.authority.Authority
 import uk.ac.ox.softeng.mauro.domain.diff.CollectionDTO
 import uk.ac.ox.softeng.mauro.domain.diff.DiffBuilder
-
 import uk.ac.ox.softeng.mauro.domain.diff.DiffableItem
 import uk.ac.ox.softeng.mauro.domain.diff.ObjectDiff
 import uk.ac.ox.softeng.mauro.domain.folder.Folder
@@ -45,7 +44,6 @@ abstract class Model<M extends DiffableItem> extends AdministeredItem implements
 
     Boolean readableByAuthenticatedUsers = false
 
-    @JsonAlias('type')
     String modelType = domainType
 
     @Nullable


### PR DESCRIPTION
Minor tweak:

Make `modelType` an alias for `domainType` for `Model`s, use `dataModelType` (JSON field `type`) as the Data Asset/Data Standard enumeration for DataModels.

This matches how mdm-core uses these fields and help import from Micronaut into Grails.