### PR TITLE
feature/repository-existsById

### DIFF
--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/cache/ItemCacheableRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/cache/ItemCacheableRepository.groovy
@@ -61,6 +61,10 @@ abstract class ItemCacheableRepository<I extends Item> implements ItemRepository
         cachedLookupById(READ_BY_ID, domainType, id)
     }
 
+    boolean existsById(UUID id){
+        repository.existsById(id)
+    }
+
     I save(I item) {
         I saved = repository.save(item)
         invalidate(item)

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/folder/dto/FolderDTO.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/folder/dto/FolderDTO.groovy
@@ -1,6 +1,6 @@
 package org.maurodata.persistence.folder.dto
 
-
+import org.maurodata.domain.facet.VersionLink
 
 import groovy.transform.CompileStatic
 import io.micronaut.core.annotation.Introspected
@@ -99,4 +99,10 @@ class FolderDTO extends Folder implements AdministeredItemDTO {
                 JOIN core.join_administered_item_to_classifier on join_administered_item_to_classifier.classifier_id = core.classifier.id
                 and join_administered_item_to_classifier.catalogue_item_id = folder_.id)''')
     List<Classifier> classifiers = []
+
+    @Nullable
+    @TypeDef(type = DataType.JSON)
+    @MappedProperty
+    @ColumnTransformer(read = '(select json_agg(version_link) from core.version_link where multi_facet_aware_item_id = folder_.id)')
+    List<VersionLink> versionLinks = []
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/model/ItemRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/model/ItemRepository.groovy
@@ -17,6 +17,8 @@ trait ItemRepository<I extends Item> implements GenericRepository<I, UUID> {
     @Nullable
     abstract I readById(UUID id)
 
+    abstract boolean existsById(UUID id)
+
     abstract I save(@Valid @NonNull I item)
 
     abstract List<I> saveAll(@Valid @NonNull Iterable<I> items)


### PR DESCRIPTION
When saving lists with existing persisted items, unique constraints are violated by re-insertion. Use it to guard:

if(item.id == null || repository.existsById(it.id)) {
repository.save(item)
}