### PR TITLE
OpenID Connect and Explorer compatibility tweaks

### DIFF
--- a/mauro-client/src/main/groovy/org/maurodata/api/security/openidprovider/OpenidConnectProvider.groovy
+++ b/mauro-client/src/main/groovy/org/maurodata/api/security/openidprovider/OpenidConnectProvider.groovy
@@ -1,7 +1,7 @@
 package org.maurodata.api.security.openidprovider
 
 class OpenidConnectProvider {
-    UUID openidProviderId
+    UUID id
     String label
     boolean standardProvider
     String authorizationEndpoint
@@ -9,9 +9,9 @@ class OpenidConnectProvider {
 
     OpenidConnectProvider(String openidProviderId, String label, Boolean standardProvider,
                           String authorizationEndpoint, String imageUrl) {
-        if(openidProviderId!=null) this.openidProviderId = UUID.fromString(openidProviderId)
+        if (openidProviderId != null) this.id = UUID.fromString(openidProviderId)
         this.label = label
-        if(standardProvider!=null) this.standardProvider = standardProvider
+        if (standardProvider != null) this.standardProvider = standardProvider
         this.authorizationEndpoint = authorizationEndpoint
         this.imageUrl = imageUrl
     }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/cache/AdministeredItemCacheableRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/cache/AdministeredItemCacheableRepository.groovy
@@ -1,5 +1,13 @@
 package org.maurodata.persistence.cache
 
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import io.micronaut.cache.annotation.CacheConfig
+import io.micronaut.cache.annotation.CacheInvalidate
+import io.micronaut.cache.annotation.Cacheable
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.core.annotation.Nullable
+import jakarta.inject.Singleton
 import org.maurodata.domain.classifier.Classifier
 import org.maurodata.domain.dataflow.DataClassComponent
 import org.maurodata.domain.datamodel.DataClass
@@ -21,15 +29,6 @@ import org.maurodata.persistence.model.AdministeredItemRepository
 import org.maurodata.persistence.terminology.TermRelationshipRepository
 import org.maurodata.persistence.terminology.TermRelationshipTypeRepository
 import org.maurodata.persistence.terminology.TermRepository
-
-import groovy.transform.CompileStatic
-import groovy.util.logging.Slf4j
-import io.micronaut.cache.annotation.CacheConfig
-import io.micronaut.cache.annotation.CacheInvalidate
-import io.micronaut.cache.annotation.Cacheable
-import io.micronaut.core.annotation.NonNull
-import io.micronaut.core.annotation.Nullable
-import jakarta.inject.Singleton
 
 @Slf4j
 @CompileStatic
@@ -152,6 +151,10 @@ abstract class AdministeredItemCacheableRepository<I extends AdministeredItem> e
             ((DataClassRepository) repository).readAllByParentDataClass_Id(parentDataClassId)
         }
 
+        // not cached
+        List<DataClass> readAllByParentDataClass(DataClass parentDataClass) {
+            ((DataClassRepository) repository).readAllByParentDataClass(parentDataClass)
+        }
 
         // not cached
         List<DataClass> readAllByDataModelAndParentDataClassIsNull(DataModel dataModel) {


### PR DESCRIPTION
* add param to disable email_verified check as Entra does not provide this (have to rely on tenant configuration instead)
* rename OpenidConnectProvider field to `id` to make mdm-explorer work
* add back repository method used by mdm-plugin-explorer