### PR TITLE
 Merge diff, and merge

### DIFF
--- a/mauro-api/src/main/groovy/org/maurodata/controller/classifier/ClassificationSchemeController.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/controller/classifier/ClassificationSchemeController.groovy
@@ -131,6 +131,13 @@ class ClassificationSchemeController extends ModelController<ClassificationSchem
 
         classificationScheme.setAssociations()
         otherClassificationScheme.setAssociations()
+
+        pathRepository.readParentItems(classificationScheme)
+        classificationScheme.updatePath()
+
+        pathRepository.readParentItems(otherClassificationScheme)
+        otherClassificationScheme.updatePath()
+
         classificationScheme.diff(otherClassificationScheme)
     }
 

--- a/mauro-api/src/main/groovy/org/maurodata/controller/datamodel/DataModelController.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/controller/datamodel/DataModelController.groovy
@@ -1,5 +1,6 @@
 package org.maurodata.controller.datamodel
 
+import org.maurodata.api.model.MergeIntoDTO
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import io.micronaut.context.annotation.Parameter
@@ -229,6 +230,13 @@ class DataModelController extends ModelController<DataModel> implements DataMode
 
         dataModel.setAssociations()
         otherDataModel.setAssociations()
+
+        pathRepository.readParentItems(dataModel)
+        dataModel.updatePath()
+
+        pathRepository.readParentItems(otherDataModel)
+        otherDataModel.updatePath()
+
         dataModel.diff(otherDataModel)
     }
 
@@ -445,338 +453,49 @@ class DataModelController extends ModelController<DataModel> implements DataMode
     @Override
     @Get(Paths.DATA_MODEL_SIMPLE_MODEL_VERSION_TREE)
     List<ModelVersionedRefDTO> simpleModelVersionTree(UUID id, @Nullable Boolean branchesOnly) {
-
-        branchesOnly = branchesOnly ?: false
-
-        final ArrayList<Model> allModels = populateVersionTree(id, branchesOnly, null)
-
-        // Create object DTOs
-
-        final ArrayList<ModelVersionedRefDTO> simpleModelVersionTreeList = new ArrayList<>(allModels.size())
-
-        for (Model model : allModels) {
-            final ModelVersionedRefDTO modelVersionedRefDTO = new ModelVersionedRefDTO(id: model.id, branch: model.branchName, branchName: model.branchName,
-                                                                                       modelVersion: model.modelVersion?.toString(), modelVersionTag: model.modelVersionTag,
-                                                                                       documentationVersion: model.documentationVersion,
-                                                                                       displayName: model.pathModelIdentifier)
-            simpleModelVersionTreeList.add(modelVersionedRefDTO)
-        }
-
-        return simpleModelVersionTreeList
+        super.simpleModelVersionTree(id, branchesOnly)
     }
 
     @Override
     @Get(Paths.DATA_MODEL_MODEL_VERSION_TREE)
     List<ModelVersionedWithTargetsRefDTO> modelVersionTree(UUID id) {
-
-        final Map<UUID, Map<String, Boolean>> flags = [:]
-        final ArrayList<Model> allModels = super.populateVersionTree(id, false, flags)
-
-        // Create object DTOs
-
-        final ArrayList<ModelVersionedWithTargetsRefDTO> modelVersionTreeList = new ArrayList<>(allModels.size())
-
-        for (Model model : allModels) {
-            final ModelVersionedWithTargetsRefDTO modelVersionedWithTargetsRefDTO = new ModelVersionedWithTargetsRefDTO(id: model.id, branch: model.branchName,
-                                                                                                                        branchName: model.branchName,
-                                                                                                                        modelVersion: model.modelVersion?.toString(),
-                                                                                                                        modelVersionTag: model.modelVersionTag,
-                                                                                                                        documentationVersion: model.documentationVersion,
-                                                                                                                        displayName: model.pathModelIdentifier)
-
-            // Have any flags been set during recursion?
-            final Map<String, Boolean> modelFlags = flags.get(modelVersionedWithTargetsRefDTO.id)
-
-            if (modelFlags != null) {
-                Boolean isNewBranchModelVersion = modelFlags.get("isNewBranchModelVersion")
-                Boolean isNewFork = modelFlags.get("isNewFork")
-
-                if (isNewBranchModelVersion != null && isNewBranchModelVersion) {
-                    modelVersionedWithTargetsRefDTO.isNewBranchModelVersion = true
-                } else if (isNewFork != null && isNewFork) {
-                    modelVersionedWithTargetsRefDTO.isNewFork = true
-                }
-            }
-
-            // Add in targets
-
-            if (model.versionLinks != null && !model.versionLinks.isEmpty()) {
-                for (VersionLink childVersion : model.versionLinks) {
-                    final UUID targetModelId = childVersion.targetModelId
-                    if (targetModelId == null) {
-                        continue
-                    }
-
-                    final VersionLinkTargetDTO versionLinkTargetDTO = new VersionLinkTargetDTO(id: targetModelId, description: childVersion.description)
-
-                    modelVersionedWithTargetsRefDTO.targets.add(versionLinkTargetDTO)
-                }
-            }
-
-            modelVersionTreeList.add(modelVersionedWithTargetsRefDTO)
-        }
-
-        return modelVersionTreeList
+        super.modelVersionTree(id)
     }
 
     @Override
     @Get(Paths.DATA_MODEL_CURRENT_MAIN_BRANCH)
     DataModel currentMainBranch(UUID id) {
-
-        // Like Highlander, there can be only one
-        // main/draft version
-        // and it downstream
-
-        final ArrayList<Model> allModels = populateVersionTree(id, true, null)
-
-        for (int m = allModels.size() - 1; m >= 0; m--) {
-            final Model givenModel = allModels.get(m)
-            if (givenModel.branchName == Model.DEFAULT_BRANCH_NAME) {
-                return givenModel as DataModel
-            }
-        }
-
-        throw new HttpStatusException(HttpStatus.NOT_FOUND, "There is no main draft model")
+        super.currentMainBranch(id)
     }
 
     @Override
     @Get(Paths.DATA_MODEL_LATEST_MODEL_VERSION)
     ModelVersionDTO latestModelVersion(UUID id) {
-        final ArrayList<Model> allModels = populateVersionTree(id, false, null)
-
-        if (allModels.size() == 0) {
-            throw new HttpStatusException(HttpStatus.NOT_FOUND, "There are no models")
-        }
-
-        ModelVersion highestVersion = null
-
-        for (int m = 0; m < allModels.size(); m++) {
-            final Model givenModel = allModels.get(m)
-            final ModelVersion modelVersion = givenModel.modelVersion
-            if (modelVersion == null) {continue}
-
-            if (highestVersion == null) {
-                highestVersion = modelVersion
-                continue
-            }
-
-            if (modelVersion > highestVersion) {
-                highestVersion = modelVersion
-            }
-        }
-
-        if (highestVersion == null) {
-            log.warn("There are no versioned models for data model :$id")
-        }
-        return new ModelVersionDTO(modelVersion: highestVersion ?: ModelVersion.from(FieldConstants.DEFAULT_MODEL_VERSION))
+        super.latestModelVersion(id)
     }
 
     @Override
     @Get(Paths.DATA_MODEL_LATEST_FINALISED_MODEL)
     ModelVersionedRefDTO latestFinalisedModel(UUID id) {
-        final ArrayList<Model> allModels = populateVersionTree(id, false, null)
-
-        if (allModels.size() == 0) {
-            throw new HttpStatusException(HttpStatus.NOT_FOUND, "There are no models")
-        }
-
-        Model highestVersionModel = null
-
-        for (int m = 0; m < allModels.size(); m++) {
-            final Model givenModel = allModels.get(m)
-            final ModelVersion modelVersion = givenModel.modelVersion
-            if (modelVersion == null) {continue}
-
-            if (highestVersionModel == null) {
-                highestVersionModel = givenModel
-                continue
-            }
-
-            if (modelVersion > highestVersionModel.modelVersion) {
-                highestVersionModel = givenModel
-            }
-        }
-
-        if (highestVersionModel == null) {
-            throw new HttpStatusException(HttpStatus.NOT_FOUND, "There are no versioned models")
-        }
-
-        return new ModelVersionedRefDTO(id: highestVersionModel.id, domainType: highestVersionModel.domainType, label: highestVersionModel.label,
-                                        branch: highestVersionModel.branchName, branchName: highestVersionModel.branchName,
-                                        modelVersion: highestVersionModel.modelVersion?.toString(), modelVersionTag: highestVersionModel.modelVersionTag,
-                                        documentationVersion: highestVersionModel.documentationVersion, displayName: highestVersionModel.pathModelIdentifier)
+        super.latestFinalisedModel(id)
     }
 
     @Get(Paths.DATA_MODEL_COMMON_ANCESTOR)
     DataModel commonAncestor(UUID id, UUID other_model_id) {
-        final DataModel left = show(id)
-        if (!left) {throw new HttpStatusException(HttpStatus.NOT_FOUND, "No data model found for id [${left.id.toString()}]")}
-        final DataModel right = show(other_model_id)
-        if (!right) {throw new HttpStatusException(HttpStatus.NOT_FOUND, "No data model found for id [${right.id.toString()}]")}
-
-        return findCommonAncestorBetweenModels(left, right)
+        super.commonAncestor(id,other_model_id)
     }
 
     @Get(Paths.DATA_MODEL_MERGE_DIFF)
     MergeDiffDTO mergeDiff(@NonNull UUID id, @NonNull UUID otherId) {
-        final DataModel dataModelOne = modelContentRepository.findWithContentById(id)
-        ErrorHandler.handleErrorOnNullObject(HttpStatus.NOT_FOUND, dataModelOne, "item with $id not found")
+        super.mergeDiff(id,otherId)
+    }
 
-        final DataModel dataModelTwo = modelContentRepository.findWithContentById(otherId)
-        ErrorHandler.handleErrorOnNullObject(HttpStatus.NOT_FOUND, dataModelTwo, "item with $otherId not found")
-
-        accessControlService.checkRole(Role.READER, dataModelOne)
-        accessControlService.checkRole(Role.READER, dataModelTwo)
-
-        final DataModel commonAncestor = findCommonAncestorBetweenModels(dataModelOne, dataModelTwo)
-
-        dataModelOne.setAssociations()
-        dataModelTwo.setAssociations()
-        commonAncestor.setAssociations()
-
-        // For a merge, there are two diffs between the common ancestor and model being merged
-
-        final ObjectDiff objectDiffOne = commonAncestor.diff(dataModelOne)
-        final ObjectDiff objectDiffTwo = commonAncestor.diff(dataModelTwo)
-
-        // Remove branchName differences since these are merges of branches
-
-        for (ObjectDiff objectDiff : ([objectDiffOne, objectDiffTwo] as List<ObjectDiff>)) {
-            final ArrayList<FieldDiff> diffsToRemove = new ArrayList<>(2)
-            for (fieldDiff in objectDiff.diffs) {
-                if (fieldDiff.name == 'branchName') {
-                    diffsToRemove.add(fieldDiff)
-                }
-            }
-            objectDiff.diffs.removeAll(diffsToRemove)
-        }
-
-        // recurse down through each diff and create a map of Path-> FieldDiff
-
-        Map<String, Map<String, FieldDiff>> flattenedDiffOne = flattenDiff(objectDiffOne)
-        Map<String, Map<String, FieldDiff>> flattenedDiffTwo = flattenDiff(objectDiffTwo)
-
-        // Collate the set of all paths used as keys
-
-        final Map<String, FieldDiff> flattenedDiffOneCreated = flattenedDiffOne.get('created')
-        final Map<String, FieldDiff> flattenedDiffOneModified = flattenedDiffOne.get('modified')
-        final Map<String, FieldDiff> flattenedDiffOneDeleted = flattenedDiffOne.get('deleted')
-
-        final Map<String, FieldDiff> flattenedDiffTwoCreated = flattenedDiffTwo.get('created')
-        final Map<String, FieldDiff> flattenedDiffTwoModified = flattenedDiffTwo.get('modified')
-        final Map<String, FieldDiff> flattenedDiffTwoDeleted = flattenedDiffTwo.get('deleted')
-
-        final List<Map<String, FieldDiff>> flattenedDiffOneMapList = [flattenedDiffOneCreated, flattenedDiffOneModified, flattenedDiffOneDeleted]
-        final List<Map<String, FieldDiff>> flattenedDiffTwoMapList = [flattenedDiffTwoCreated, flattenedDiffTwoModified, flattenedDiffTwoDeleted]
-
-        final Set<String> allPaths = new LinkedHashSet<>()
-        for (Map<String, FieldDiff> pathToFieldDiff : flattenedDiffOneMapList + flattenedDiffTwoMapList) {
-            final Set keys = pathToFieldDiff.keySet()
-            allPaths.addAll(keys)
-        }
-
-        List<Path.PathNode> pathNodes = []
-
-        AdministeredItem node = dataModelOne
-        pathNodes.add(0, new Path.PathNode(prefix: node.pathPrefix, identifier: node.pathIdentifier, modelIdentifier: node.pathModelIdentifier))
-
-        final Path path = new Path(pathNodes)
-        final String sourcePath = path.toString()
-
-        final List<MergeFieldDiffDTO> diffs = []
-        final MergeDiffDTO mergeDiffDTO = new MergeDiffDTO(sourceId: dataModelOne.id, targetId: dataModelTwo.id, path: sourcePath, label: dataModelOne.label, diffs: diffs)
-
-        // for each key, compare what needs to be done to merge
-        // changes are only in conflict when the value of the ancestor, branch one, branch two all have
-        // different values e.g. there are 3 distinct values
-        // For each distinct path, look up the value held in each of the three places and add it to a set
-        // if the set has 3 values, there is a conflict, otherwise it a simple change
-
-        for (String key : allPaths) {
-            FieldDiff fieldDiffOne = null
-            String _type = 'modification'
-            lookingInOne:
-            for (Map<String, FieldDiff> pathToFieldDiff : flattenedDiffOneMapList) {
-                final foundFieldDiff = pathToFieldDiff.get(key)
-                if (foundFieldDiff != null) {
-                    fieldDiffOne = foundFieldDiff
-                    if (pathToFieldDiff == flattenedDiffOneCreated) {
-                        _type = 'creation'
-                    } else if (pathToFieldDiff == flattenedDiffOneDeleted) {
-                        _type = 'deletion'
-                    }
-                    break lookingInOne
-                }
-            }
-
-            FieldDiff fieldDiffTwo = null
-            lookingInTwo:
-            for (Map<String, FieldDiff> pathToFieldDiff : flattenedDiffTwoMapList) {
-                final foundFieldDiff = pathToFieldDiff.get(key)
-                if (foundFieldDiff != null) {
-                    fieldDiffTwo = foundFieldDiff
-                    break lookingInTwo
-                }
-            }
-
-            // Find the common ancestor version
-            // In the FieldDiff lhs is the value object from the commonAncestor, rhs is a branch
-
-            final Object fieldOneValue, fieldTwoValue, ancestorValue
-            final String fieldName
-
-            // Establish the ancestorValue first, since it is the backstop value
-
-            if (fieldDiffOne != null) {
-                ancestorValue = fieldDiffOne.left
-                fieldName = fieldDiffOne.name
-            } else if (fieldDiffTwo != null) {
-                ancestorValue = fieldDiffTwo.left
-                fieldName = fieldDiffTwo.name
-            } else {
-                ancestorValue = null
-                fieldName = null
-            }
-
-            // If there is a change, record the value
-            // or else it is the same as the ancestor value
-
-            if (fieldDiffOne != null) {
-                fieldOneValue = fieldDiffOne.right
-            } else {
-                fieldOneValue = ancestorValue
-            }
-
-            if (fieldDiffTwo != null) {
-                fieldTwoValue = fieldDiffTwo.right
-            } else {
-                fieldTwoValue = ancestorValue
-            }
-
-            // If a fieldValueOne or fieldValueTwo value do not exist and the ancestor value does, they are
-            // no different from the ancestor value
-            final HashSet<Object> values = [fieldOneValue, fieldTwoValue, ancestorValue]
-
-            final boolean isMergeConflict = values.size() == 3
-
-            // Because the target branch is branch two, we are only interested in
-            // changes or conflicts coming from the source branch (branch one)
-            // anything that is not a conflict from branch two is a no-op
-            //                 | ---------------(Branch Two)-->
-            //  (ancestor) --> | ---(Branch One)----^
-
-            if (!isMergeConflict && fieldDiffOne == null) {
-                continue
-            }
-
-            final MergeFieldDiffDTO mergeFieldDiffDTO = new MergeFieldDiffDTO(fieldName: fieldName, sourceValue: fieldOneValue, targetValue: fieldTwoValue,
-                                                                              commonAncestorValue: ancestorValue, isMergeConflict: isMergeConflict, _type: _type)
-
-            diffs.add(mergeFieldDiffDTO)
-
-        }
-
-        return mergeDiffDTO
+    @Audit
+    @Transactional
+    @ExecuteOn(TaskExecutors.BLOCKING)
+    @Put(Paths.DATA_MODEL_MERGE_INTO)
+    DataModel mergeInto(@NonNull UUID id, @NonNull UUID otherId, @Body @Nullable MergeIntoDTO mergeIntoDTO){
+        super.mergeInto(id,otherId,mergeIntoDTO)
     }
 
     @Get(Paths.DATA_MODEL_PERMISSIONS)

--- a/mauro-api/src/main/groovy/org/maurodata/controller/datamodel/DataTypeController.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/controller/datamodel/DataTypeController.groovy
@@ -90,7 +90,11 @@ class DataTypeController extends AdministeredItemController<DataType, DataModel>
         Item parent = super.validate(cleanItem, dataModelId)
         cleanItem = dataTypeService.validateDataType(cleanItem, parent)
 
-
+        if (cleanItem.isReferenceType()) {
+            if (cleanItem.referenceClass.id == parent.id) {
+                ErrorHandler.handleError(HttpStatus.UNPROCESSABLE_ENTITY, "Data class element shouldn't reference it")
+            }
+        }
         if (dataType.isModelType()) {
 
             // Either the dataType is finalised
@@ -99,7 +103,7 @@ class DataTypeController extends AdministeredItemController<DataType, DataModel>
 
             ModelCacheableRepository domainRepository = repositoryService.getModelRepository(dataType.modelResourceDomainType)
 
-            AdministeredItem dataTypeAdministeredItem = (AdministeredItem) domainRepository.findById(dataType.modelResourceId)
+            AdministeredItem dataTypeAdministeredItem = (AdministeredItem) domainRepository.readById(dataType.modelResourceId)
 
             pathRepository.readParentItems(dataTypeAdministeredItem)
             pathRepository.readParentItems(parent)
@@ -109,7 +113,6 @@ class DataTypeController extends AdministeredItemController<DataType, DataModel>
 
             Item dataTypeVersionedFolder = pathToDataType.findAncestorNodeItem(dataType.modelResourceId, "VersionedFolder")
             Item dataModelVersionedFolder = null
-            if (dataTypeVersionedFolder != null) {System.out.println(dataTypeVersionedFolder.toString());}
 
             if (dataTypeVersionedFolder != null) {
                 dataModelVersionedFolder = pathToDataModel.findAncestorNodeItem(parent.id, "VersionedFolder")

--- a/mauro-api/src/main/groovy/org/maurodata/controller/facet/EditController.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/controller/facet/EditController.groovy
@@ -4,6 +4,7 @@ import org.maurodata.api.Paths
 import org.maurodata.api.facet.EditApi
 import org.maurodata.audit.Audit
 import org.maurodata.domain.facet.Edit
+import org.maurodata.domain.facet.EditType
 import org.maurodata.domain.model.AdministeredItem
 import org.maurodata.domain.security.Role
 import org.maurodata.persistence.cache.FacetCacheableRepository
@@ -65,5 +66,19 @@ class EditController extends FacetController<Edit> implements EditApi {
     @Delete(Paths.EDIT_ID)
     HttpResponse delete(String domainType, UUID domainId, UUID id) {
         super.delete(id)
+    }
+
+    @Override
+    Edit createEntity(@NonNull AdministeredItem administeredItem, @NonNull Edit edit) {
+        if (!accessControlService.enabled || accessControlService.user == null) {return edit}
+        super.createEntity(administeredItem, edit)
+    }
+
+    Edit createEdit(@NonNull AdministeredItem administeredItem, @NonNull EditType editType, @NonNull String theDescription) {
+        final Edit edit = new Edit().tap {
+            title = editType
+            description = theDescription
+        }
+        createEntity(administeredItem, edit)
     }
 }

--- a/mauro-api/src/main/groovy/org/maurodata/controller/folder/FolderController.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/controller/folder/FolderController.groovy
@@ -39,6 +39,7 @@ import io.micronaut.security.annotation.Secured
 import io.micronaut.security.rules.SecurityRule
 import io.micronaut.transaction.annotation.Transactional
 import jakarta.inject.Inject
+import jakarta.inject.Named
 
 @Slf4j
 @CompileStatic

--- a/mauro-api/src/main/groovy/org/maurodata/controller/folder/VersionedFolderController.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/controller/folder/VersionedFolderController.groovy
@@ -1,5 +1,6 @@
 package org.maurodata.controller.folder
 
+import org.maurodata.api.model.MergeIntoDTO
 import com.fasterxml.jackson.core.Versioned
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
@@ -205,345 +206,51 @@ class VersionedFolderController extends ModelController<Folder> implements Versi
     @Override
     @Get(Paths.VERSIONED_FOLDER_SIMPLE_MODEL_VERSION_TREE)
     List<ModelVersionedRefDTO> simpleModelVersionTree(UUID id, @Nullable Boolean branchesOnly) {
-
-        branchesOnly = branchesOnly ?: false
-
-        final List<Model> allModels = populateVersionTree(id, branchesOnly, null)
-
-        // Create object DTOs
-
-        final ArrayList<ModelVersionedRefDTO> simpleModelVersionTreeList = new ArrayList<>(allModels.size())
-
-        allModels.each {Model model ->
-            simpleModelVersionTreeList.add(
-                new ModelVersionedRefDTO(id: model.id, branch: model.branchName, branchName: model.branchName, modelVersion: model.modelVersion?.toString(),
-                                         modelVersionTag: model.modelVersionTag, documentationVersion: model.documentationVersion, displayName: model.pathModelIdentifier))
-        }
-
-        simpleModelVersionTreeList
+        super.simpleModelVersionTree(id,branchesOnly)
     }
 
     @Override
     @Get(Paths.VERSIONED_FOLDER_MODEL_VERSION_TREE)
     List<ModelVersionedWithTargetsRefDTO> modelVersionTree(UUID id) {
-
-        final Map<UUID, Map<String, Boolean>> flags = [:]
-        final List<Model> allModels = super.populateVersionTree(id, false, flags)
-
-        // Create object DTOs
-
-        final ArrayList<ModelVersionedWithTargetsRefDTO> modelVersionTreeList = new ArrayList<>(allModels.size())
-
-        for (Model model : allModels) {
-            final ModelVersionedWithTargetsRefDTO modelVersionedWithTargetsRefDTO = new ModelVersionedWithTargetsRefDTO(id: model.id, branch: model.branchName,
-                                                                                                                        branchName: model.branchName,
-                                                                                                                        modelVersion: model.modelVersion?.toString(),
-                                                                                                                        modelVersionTag: model.modelVersionTag,
-                                                                                                                        documentationVersion: model.documentationVersion,
-                                                                                                                        displayName: model.pathModelIdentifier)
-
-            // Have any flags been set during recursion?
-            final Map<String, Boolean> modelFlags = flags.get(modelVersionedWithTargetsRefDTO.id)
-
-            if (modelFlags != null) {
-                Boolean isNewBranchModelVersion = modelFlags.get("isNewBranchModelVersion")
-                Boolean isNewFork = modelFlags.get("isNewFork")
-
-                if (isNewBranchModelVersion != null && isNewBranchModelVersion) {
-                    modelVersionedWithTargetsRefDTO.isNewBranchModelVersion = true
-                } else if (isNewFork != null && isNewFork) {
-                    modelVersionedWithTargetsRefDTO.isNewFork = true
-                }
-            }
-
-            // Add in targets
-
-            if (model.versionLinks != null && !model.versionLinks.isEmpty()) {
-                for (VersionLink childVersion : model.versionLinks) {
-                    final UUID targetModelId = childVersion.targetModelId
-                    if (targetModelId == null) {
-                        continue
-                    }
-
-                    final VersionLinkTargetDTO versionLinkTargetDTO = new VersionLinkTargetDTO(id: targetModelId, description: childVersion.description)
-
-                    modelVersionedWithTargetsRefDTO.targets.add(versionLinkTargetDTO)
-                }
-            }
-
-            modelVersionTreeList.add(modelVersionedWithTargetsRefDTO)
-        }
-
-        modelVersionTreeList
+        super.modelVersionTree(id)
     }
 
     @Override
     @Get(Paths.VERSIONED_FOLDER_CURRENT_MAIN_BRANCH)
     Folder currentMainBranch(UUID id) {
-
-        // Like Highlander, there can be only one
-        // main/draft version
-        // and it downstream
-
-        final List<Model> allModels = populateVersionTree(id, true, null)
-
-        for (int m = allModels.size() - 1; m >= 0; m--) {
-            final Model givenModel = allModels.get(m)
-            if (givenModel.branchName == Model.DEFAULT_BRANCH_NAME) {
-                return givenModel as Folder
-            }
-        }
-
-        throw new HttpStatusException(HttpStatus.NOT_FOUND, "There is no main draft model")
+        super.currentMainBranch(id)
     }
 
     @Override
     @Get(Paths.VERSIONED_FOLDER_LATEST_MODEL_VERSION)
     ModelVersionDTO latestModelVersion(UUID id) {
-        final List<Model> allModels = populateVersionTree(id, false, null)
-
-        if (allModels.size() == 0) {
-            throw new HttpStatusException(HttpStatus.NOT_FOUND, "There are no models")
-        }
-
-        ModelVersion highestVersion = null
-
-        for (int m = 0; m < allModels.size(); m++) {
-            final Model givenModel = allModels.get(m)
-            final ModelVersion modelVersion = givenModel.modelVersion
-            if (modelVersion == null) {
-                continue
-            }
-
-            if (highestVersion == null) {
-                highestVersion = modelVersion
-                continue
-            }
-
-            if (modelVersion > highestVersion) {
-                highestVersion = modelVersion
-            }
-        }
-
-        if (highestVersion == null) {
-            new ModelVersionDTO(modelVersion: "0.0.0")
-        }
-
-        return new ModelVersionDTO(modelVersion: highestVersion)
+        super.latestModelVersion(id)
     }
 
     @Override
     @Get(Paths.VERSIONED_FOLDER_LATEST_FINALISED_MODEL)
     ModelVersionedRefDTO latestFinalisedModel(UUID id) {
-        final List<Model> allModels = populateVersionTree(id, false, null)
-
-        if (allModels.size() == 0) {
-            throw new HttpStatusException(HttpStatus.NOT_FOUND, "There are no models")
-        }
-
-        Model highestVersionModel = null
-
-        for (int m = 0; m < allModels.size(); m++) {
-            final Model givenModel = allModels.get(m)
-            final ModelVersion modelVersion = givenModel.modelVersion
-            if (modelVersion == null) {
-                continue
-            }
-
-            if (highestVersionModel == null) {
-                highestVersionModel = givenModel
-                continue
-            }
-
-            if (modelVersion > highestVersionModel.modelVersion) {
-                highestVersionModel = givenModel
-            }
-        }
-
-        if (highestVersionModel == null) {
-            throw new HttpStatusException(HttpStatus.NOT_FOUND, "There are no versioned models")
-        }
-
-        return new ModelVersionedRefDTO(id: highestVersionModel.id, domainType: highestVersionModel.domainType, label: highestVersionModel.label,
-                                        branch: highestVersionModel.branchName, branchName: highestVersionModel.branchName,
-                                        modelVersion: highestVersionModel.modelVersion?.toString(), modelVersionTag: highestVersionModel.modelVersionTag,
-                                        documentationVersion: highestVersionModel.documentationVersion, displayName: highestVersionModel.pathModelIdentifier)
+        super.latestFinalisedModel(id)
     }
 
     @Get(Paths.VERSIONED_FOLDER_COMMON_ANCESTOR)
     Folder commonAncestor(UUID id, UUID other_model_id) {
-        final Folder left = show(id)
-        if (!left) {
-            throw new HttpStatusException(HttpStatus.NOT_FOUND, "No data model found for id [${left.id.toString()}]")
-        }
-        final Folder right = show(other_model_id)
-        if (!right) {
-            throw new HttpStatusException(HttpStatus.NOT_FOUND, "No data model found for id [${right.id.toString()}]")
-        }
-
-        return findCommonAncestorBetweenModels(left, right)
+        super.commonAncestor(id,other_model_id)
     }
 
     @Get(Paths.VERSIONED_FOLDER_MERGE_DIFF)
-    MergeDiffDTO mergeDiff(@NonNull UUID id, @NonNull UUID otherId) {
-        final Folder dataModelOne = modelContentRepository.findWithContentById(id)
-        ErrorHandler.handleErrorOnNullObject(HttpStatus.NOT_FOUND, dataModelOne, "item with $id not found")
-
-        final Folder dataModelTwo = modelContentRepository.findWithContentById(otherId)
-        ErrorHandler.handleErrorOnNullObject(HttpStatus.NOT_FOUND, dataModelTwo, "item with $otherId not found")
-
-        accessControlService.checkRole(Role.READER, dataModelOne)
-        accessControlService.checkRole(Role.READER, dataModelTwo)
-
-        final Folder commonAncestor = findCommonAncestorBetweenModels(dataModelOne, dataModelTwo)
-
-        dataModelOne.setAssociations()
-        dataModelTwo.setAssociations()
-        commonAncestor.setAssociations()
-
-        // For a merge, there are two diffs between the common ancestor and model being merged
-
-        final ObjectDiff objectDiffOne = commonAncestor.diff(dataModelOne)
-        final ObjectDiff objectDiffTwo = commonAncestor.diff(dataModelTwo)
-
-        // Remove branchName differences since these are merges of branches
-
-        for (ObjectDiff objectDiff : ([objectDiffOne, objectDiffTwo] as List<ObjectDiff>)) {
-            final ArrayList<FieldDiff> diffsToRemove = new ArrayList<>(2)
-            for (fieldDiff in objectDiff.diffs) {
-                if (fieldDiff.name == 'branchName') {
-                    diffsToRemove.add(fieldDiff)
-                }
-            }
-            objectDiff.diffs.removeAll(diffsToRemove)
-        }
-
-        // recurse down through each diff and create a map of Path-> FieldDiff
-
-        Map<String, Map<String, FieldDiff>> flattenedDiffOne = flattenDiff(objectDiffOne)
-        Map<String, Map<String, FieldDiff>> flattenedDiffTwo = flattenDiff(objectDiffTwo)
-
-        // Collate the set of all paths used as keys
-
-        final Map<String, FieldDiff> flattenedDiffOneCreated = flattenedDiffOne.get('created')
-        final Map<String, FieldDiff> flattenedDiffOneModified = flattenedDiffOne.get('modified')
-        final Map<String, FieldDiff> flattenedDiffOneDeleted = flattenedDiffOne.get('deleted')
-
-        final Map<String, FieldDiff> flattenedDiffTwoCreated = flattenedDiffTwo.get('created')
-        final Map<String, FieldDiff> flattenedDiffTwoModified = flattenedDiffTwo.get('modified')
-        final Map<String, FieldDiff> flattenedDiffTwoDeleted = flattenedDiffTwo.get('deleted')
-
-        final List<Map<String, FieldDiff>> flattenedDiffOneMapList = [flattenedDiffOneCreated, flattenedDiffOneModified, flattenedDiffOneDeleted]
-        final List<Map<String, FieldDiff>> flattenedDiffTwoMapList = [flattenedDiffTwoCreated, flattenedDiffTwoModified, flattenedDiffTwoDeleted]
-
-        final Set<String> allPaths = new LinkedHashSet<>()
-        for (Map<String, FieldDiff> pathToFieldDiff : flattenedDiffOneMapList + flattenedDiffTwoMapList) {
-            final Set keys = pathToFieldDiff.keySet()
-            allPaths.addAll(keys)
-        }
-
-        List<Path.PathNode> pathNodes = []
-
-        AdministeredItem node = dataModelOne
-        pathNodes.add(0, new Path.PathNode(prefix: node.pathPrefix, identifier: node.pathIdentifier, modelIdentifier: node.pathModelIdentifier))
-
-        final Path path = new Path(pathNodes)
-        final String sourcePath = path.toString()
-
-        final List<MergeFieldDiffDTO> diffs = []
-        final MergeDiffDTO mergeDiffDTO = new MergeDiffDTO(sourceId: dataModelOne.id, targetId: dataModelTwo.id, path: sourcePath, label: dataModelOne.label, diffs: diffs)
-
-        // for each key, compare what needs to be done to merge
-        // changes are only in conflict when the value of the ancestor, branch one, branch two all have
-        // different values e.g. there are 3 distinct values
-        // For each distinct path, look up the value held in each of the three places and add it to a set
-        // if the set has 3 values, there is a conflict, otherwise it a simple change
-
-        for (String key : allPaths) {
-            FieldDiff fieldDiffOne = null
-            String _type = 'modification'
-            lookingInOne:
-            for (Map<String, FieldDiff> pathToFieldDiff : flattenedDiffOneMapList) {
-                final foundFieldDiff = pathToFieldDiff.get(key)
-                if (foundFieldDiff != null) {
-                    fieldDiffOne = foundFieldDiff
-                    if (pathToFieldDiff == flattenedDiffOneCreated) {
-                        _type = 'creation'
-                    } else if (pathToFieldDiff == flattenedDiffOneDeleted) {
-                        _type = 'deletion'
-                    }
-                    break lookingInOne
-                }
-            }
-
-            FieldDiff fieldDiffTwo = null
-            lookingInTwo:
-            for (Map<String, FieldDiff> pathToFieldDiff : flattenedDiffTwoMapList) {
-                final foundFieldDiff = pathToFieldDiff.get(key)
-                if (foundFieldDiff != null) {
-                    fieldDiffTwo = foundFieldDiff
-                    break lookingInTwo
-                }
-            }
-
-            // Find the common ancestor version
-            // In the FieldDiff lhs is the value object from the commonAncestor, rhs is a branch
-
-            final Object fieldOneValue, fieldTwoValue, ancestorValue
-            final String fieldName
-
-            // Establish the ancestorValue first, since it is the backstop value
-
-            if (fieldDiffOne != null) {
-                ancestorValue = fieldDiffOne.left
-                fieldName = fieldDiffOne.name
-            } else if (fieldDiffTwo != null) {
-                ancestorValue = fieldDiffTwo.left
-                fieldName = fieldDiffTwo.name
-            } else {
-                ancestorValue = null
-                fieldName = null
-            }
-
-            // If there is a change, record the value
-            // or else it is the same as the ancestor value
-
-            if (fieldDiffOne != null) {
-                fieldOneValue = fieldDiffOne.right
-            } else {
-                fieldOneValue = ancestorValue
-            }
-
-            if (fieldDiffTwo != null) {
-                fieldTwoValue = fieldDiffTwo.right
-            } else {
-                fieldTwoValue = ancestorValue
-            }
-
-            // If a fieldValueOne or fieldValueTwo value do not exist and the ancestor value does, they are
-            // no different from the ancestor value
-            final HashSet<Object> values = [fieldOneValue, fieldTwoValue, ancestorValue]
-
-            final boolean isMergeConflict = values.size() == 3
-
-            // Because the target branch is branch two, we are only interested in
-            // changes or conflicts coming from the source branch (branch one)
-            // anything that is not a conflict from branch two is a no-op
-            //                 | ---------------(Branch Two)-->
-            //  (ancestor) --> | ---(Branch One)----^
-
-            if (!isMergeConflict && fieldDiffOne == null) {
-                continue
-            }
-
-            final MergeFieldDiffDTO mergeFieldDiffDTO = new MergeFieldDiffDTO(fieldName: fieldName, sourceValue: fieldOneValue, targetValue: fieldTwoValue,
-                                                                              commonAncestorValue: ancestorValue, isMergeConflict: isMergeConflict, _type: _type)
-
-            diffs.add(mergeFieldDiffDTO)
-
-        }
-
-        return mergeDiffDTO
+    MergeDiffDTO mergeDiff(@NonNull UUID id, @NonNull UUID otherId)
+    {
+        super.mergeDiff(id,otherId)
     }
 
+    @Audit
+    @Transactional
+    @ExecuteOn(TaskExecutors.BLOCKING)
+    @Override
+    @Put(Paths.VERSIONED_FOLDER_MERGE_INTO)
+    Folder mergeInto(@NonNull UUID id, @NonNull UUID otherId, @Body @Nullable MergeIntoDTO mergeIntoDTO)
+    {
+        super.mergeInto(id,otherId,mergeIntoDTO)
+    }
 }

--- a/mauro-api/src/main/groovy/org/maurodata/controller/model/ModelController.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/controller/model/ModelController.groovy
@@ -1,23 +1,42 @@
 package org.maurodata.controller.model
 
 import org.maurodata.ErrorHandler
+import org.maurodata.FieldConstants
+import org.maurodata.api.model.FieldPatchDataDTO
+import org.maurodata.api.model.MergeDiffDTO
+import org.maurodata.api.model.MergeFieldDiffDTO
+import org.maurodata.api.model.MergeIntoDTO
 import org.maurodata.api.model.ModelApi
 import org.maurodata.api.model.ModelRefDTO
+import org.maurodata.api.model.ModelVersionDTO
+import org.maurodata.api.model.ModelVersionedRefDTO
+import org.maurodata.api.model.ModelVersionedWithTargetsRefDTO
+import org.maurodata.api.model.ObjectPatchDataDTO
 import org.maurodata.api.model.PermissionsDTO
 import org.maurodata.api.model.VersionLinkDTO
+import org.maurodata.api.model.VersionLinkTargetDTO
+import org.maurodata.controller.facet.EditController
 import org.maurodata.domain.datamodel.DataModel
 import org.maurodata.domain.diff.ArrayDiff
+import org.maurodata.domain.diff.BaseCollectionDiff
+import org.maurodata.domain.diff.CollectionDiff
 import org.maurodata.domain.diff.FieldDiff
 import org.maurodata.domain.diff.ObjectDiff
+import org.maurodata.domain.facet.EditType
+import org.maurodata.domain.facet.Facet
 import org.maurodata.domain.facet.ReferenceFile
 import org.maurodata.domain.facet.VersionLink
 import org.maurodata.domain.folder.Folder
 import org.maurodata.domain.model.AdministeredItem
+import org.maurodata.domain.model.Item
+import org.maurodata.domain.model.ItemReference
+import org.maurodata.domain.model.ItemReferencer
 import org.maurodata.domain.model.Model
 import org.maurodata.domain.model.ModelService
 import org.maurodata.domain.model.Path
 import org.maurodata.domain.model.version.CreateNewVersionData
 import org.maurodata.domain.model.version.FinaliseData
+import org.maurodata.domain.model.version.ModelVersion
 import org.maurodata.domain.security.CatalogueUser
 import org.maurodata.domain.security.Role
 import org.maurodata.domain.security.UserGroup
@@ -28,6 +47,7 @@ import org.maurodata.persistence.cache.FacetCacheableRepository
 import org.maurodata.persistence.cache.ModelCacheableRepository
 import org.maurodata.persistence.cache.ModelCacheableRepository.FolderCacheableRepository
 import org.maurodata.persistence.facet.VersionLinkRepository
+import org.maurodata.persistence.model.AdministeredItemContentRepository
 import org.maurodata.persistence.model.AdministeredItemRepository
 import org.maurodata.persistence.model.ModelContentRepository
 
@@ -50,16 +70,21 @@ import io.micronaut.http.HttpHeaders
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
 import io.micronaut.http.annotation.Body
+import io.micronaut.http.exceptions.HttpException
 import io.micronaut.http.exceptions.HttpStatusException
 import io.micronaut.http.multipart.CompletedFileUpload
 import io.micronaut.http.multipart.CompletedPart
+import io.micronaut.http.server.exceptions.InternalServerException
 import io.micronaut.http.server.multipart.MultipartBody
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
 import io.micronaut.security.annotation.Secured
 import io.micronaut.security.rules.SecurityRule
 import io.micronaut.transaction.annotation.Transactional
 import jakarta.inject.Inject
 import reactor.core.publisher.Flux
 
+import java.lang.reflect.Method
 import java.nio.charset.StandardCharsets
 
 @Slf4j
@@ -74,8 +99,8 @@ abstract class ModelController<M extends Model> extends AdministeredItemControll
     List<String> getDisallowedProperties() {
         log.debug '***** ModelController::getDisallowedProperties *****'
         super.disallowedProperties +
-                ['finalised', 'dateFinalised', 'readableByEveryone', 'readableByAuthenticatedUsers', 'modelType', 'deleted', 'folder', 'branchName',
-                 'modelVersion', 'modelVersionTag']
+        ['finalised', 'dateFinalised', 'readableByEveryone', 'readableByAuthenticatedUsers', 'modelType', 'deleted', 'folder', 'branchName',
+         'modelVersion', 'modelVersionTag']
     }
 
     @Override
@@ -100,6 +125,12 @@ abstract class ModelController<M extends Model> extends AdministeredItemControll
 
     @Inject
     VersionLinkRepository versionLinkRepositoryUncached
+
+    @Inject
+    EditController editController
+
+    @Inject
+    List<AdministeredItemContentRepository> administeredItemContentRepositories
 
     ModelController(Class<M> modelClass, AdministeredItemCacheableRepository<M> modelRepository, FolderCacheableRepository folderRepository,
                     ModelContentRepository<M> modelContentRepository) {
@@ -154,10 +185,9 @@ abstract class ModelController<M extends Model> extends AdministeredItemControll
         existing.updatePath()
         modelRepository.update(original, existing)
     }
-    
+
     @Transactional
     HttpResponse delete(UUID id, @Body @Nullable M model, @Nullable Boolean permanent) {
-
         M modelToDelete = (M) modelContentRepository.findWithContentById(id)
 
         if (modelToDelete == null) {
@@ -247,7 +277,7 @@ abstract class ModelController<M extends Model> extends AdministeredItemControll
     ListResponse<M> listAll(@Nullable PaginationParams params = new PaginationParams()) {
 
         List<M> models = modelRepository.readAll()
-        models = models.findAll { accessControlService.canDoRole(Role.READER, it) }
+        models = models.findAll {accessControlService.canDoRole(Role.READER, it)}
         models.each {
             pathRepository.readParentItems(it)
             it.updatePath()
@@ -288,18 +318,6 @@ abstract class ModelController<M extends Model> extends AdministeredItemControll
         savedCopy
     }
 
-    //todo: implement actual
-    List<Map> simpleModelVersionTree(UUID id) {
-        [
-                [
-                        id         : id,
-                        branch     : 'main',
-                        displayName: 'main'
-                ]
-        ] as List<Map>
-    }
-
-
     protected M createCopyModelWithAssociations(M existing, CreateNewVersionData createNewVersionData) {
         M copy = modelService.createNewBranchModelVersion(existing, createNewVersionData.branchName)
         copy.parent = existing.parent
@@ -330,11 +348,11 @@ abstract class ModelController<M extends Model> extends AdministeredItemControll
 
     @NonNull
     AdministeredItemRepository getRepository(AdministeredItem item) {
-        administeredItemRepositories.find { it.handles(item.class) || it.handles(item.domainType) }
+        administeredItemRepositories.find {it.handles(item.class) || it.handles(item.domainType)}
     }
 
     <P extends ImportParameters> P readFromMultipartFormBody(MultipartBody body, Class<P> parametersClass) {
-        Map<String, Object> importMap = Flux.from(body).collectList().block().collectEntries { CompletedPart cp ->
+        Map<String, Object> importMap = Flux.from(body).collectList().block().collectEntries {CompletedPart cp ->
             if (cp instanceof CompletedFileUpload) {
                 return [cp.name, new FileParameter(cp.filename, cp.contentType.toString(), cp.bytes)]
             } else {
@@ -370,7 +388,7 @@ abstract class ModelController<M extends Model> extends AdministeredItemControll
         Folder folder = folderRepository.readById(importParameters.folderId)
         ErrorHandler.handleErrorOnNullObject(HttpStatus.NOT_FOUND, folder, "Folder with id $importParameters.folderId not found")
         accessControlService.checkRole(Role.EDITOR, folder)
-        List<M> saved = imported.collect { M imp ->
+        List<M> saved = imported.collect {M imp ->
             imp.folder = folder
             log.info '** about to saveWithContentBatched... **'
             updateCreationProperties(imp)
@@ -390,7 +408,7 @@ abstract class ModelController<M extends Model> extends AdministeredItemControll
 
         }
         log.info '** finished saveWithContentBatched **'
-        List<M> smallerResponse = saved.collect { model ->
+        List<M> smallerResponse = saved.collect {model ->
             show(model.id)
         }
         ListResponse.from(smallerResponse)
@@ -404,7 +422,7 @@ abstract class ModelController<M extends Model> extends AdministeredItemControll
     protected void getReferenceFileFileContent(Collection<AdministeredItem> administeredItems) {
         administeredItems.each {
             if (it.referenceFiles) {
-                it.referenceFiles.each { referenceFile ->
+                it.referenceFiles.each {referenceFile ->
                     if (!referenceFile.fileContents) {
                         log.debug("Model $it.id has reference files. file: $referenceFile.fileName, filecontents is $referenceFile.fileContents")
                         ReferenceFile retrieved = referenceFileCacheableRepository.findById(referenceFile.id) as ReferenceFile
@@ -426,9 +444,9 @@ abstract class ModelController<M extends Model> extends AdministeredItemControll
         byte[] fileContents = mauroPlugin.exportModel(model)
         String filename = mauroPlugin.getFileName(model)
         HttpResponse
-                .ok(fileContents)
-                .header(HttpHeaders.CONTENT_LENGTH, Long.toString(fileContents.length))
-                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=${filename}")
+            .ok(fileContents)
+            .header(HttpHeaders.CONTENT_LENGTH, Long.toString(fileContents.length))
+            .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=${filename}")
     }
 
     protected VersionLinkDTO constructVersionLinkDTO(final M sourceModel, final VersionLink versionLink) {
@@ -440,10 +458,11 @@ abstract class ModelController<M extends Model> extends AdministeredItemControll
         }
 
         ModelRefDTO sourceModelDto = new ModelRefDTO(id: sourceModel.id, domainType: sourceModel.domainType, label: sourceModel.label)
-        ModelRefDTO targetModelDto = new ModelRefDTO(id: targetModel.id, domainType: targetModel.domainType, label: targetModel.label, model: targetModel.owner? targetModel.owner.id : null )
+        ModelRefDTO targetModelDto = new ModelRefDTO(id: targetModel.id, domainType: targetModel.domainType, label: targetModel.label,
+                                                     model: targetModel.owner ? targetModel.owner.id : null)
 
         final VersionLinkDTO versionLinkDTO = new VersionLinkDTO(id: versionLink.id, linkType: versionLink.versionLinkType, sourceModel: sourceModelDto,
-                targetModel: targetModelDto)
+                                                                 targetModel: targetModelDto)
 
         versionLinkDTO
     }
@@ -455,17 +474,24 @@ abstract class ModelController<M extends Model> extends AdministeredItemControll
 
         if (!finalisedLeftParent) {
             throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
-                    "MS01. Model [${leftModel.id.toString()}] has no finalised parent therefore cannot have a common ancestor with Model " +
-                            "[${rightModel.id}]")
+                                          "MS01. Model [${leftModel.id.toString()}] has no finalised parent therefore cannot have a common ancestor with Model " +
+                                          "[${rightModel.id}]")
         }
 
         if (!finalisedRightParent) {
             throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
-                    "MS02. Model [${rightModel.id.toString()}] has no finalised parent therefore cannot have a common ancestor with Model " +
-                            "[${leftModel.id}]")
+                                          "MS02. Model [${rightModel.id.toString()}] has no finalised parent therefore cannot have a common ancestor with Model " +
+                                          "[${leftModel.id}]")
         }
 
-        return (finalisedLeftParent.modelVersion < finalisedRightParent.modelVersion) ? finalisedLeftParent : finalisedRightParent
+        final M chosenCommonAncestor = (finalisedLeftParent.modelVersion < finalisedRightParent.modelVersion) ? finalisedLeftParent : finalisedRightParent
+
+        if (!isOnVersionPath(finalisedLeftParent, chosenCommonAncestor) || !isOnVersionPath(finalisedRightParent, chosenCommonAncestor)) {
+            throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                                          "MS04. Models don't share a common ancestor")
+        }
+
+        chosenCommonAncestor
     }
 
     M getFinalisedParent(final M model) {
@@ -489,6 +515,28 @@ abstract class ModelController<M extends Model> extends AdministeredItemControll
         }
 
         return null
+    }
+
+    boolean isOnVersionPath(final M modelToFind, final M asAncestorOf) {
+        M currentModel = asAncestorOf
+
+        for (; ;) {
+            if (currentModel == null) {
+                break
+            }
+            final UUID currentId = currentModel.id
+            if (currentId == modelToFind.id) {return true}
+
+            final UUID sourceModelUUID = versionLinkRepositoryUncached.findSourceModel(currentId)
+
+            if (sourceModelUUID != null) {
+                currentModel = modelContentRepository.findWithContentById(sourceModelUUID)
+                continue
+            }
+            break
+        }
+
+        return false
     }
 
     ArrayList<Model> populateVersionTree(UUID id, boolean branchesOnly, final Map<UUID, Map<String, Boolean>> flags) {
@@ -563,13 +611,13 @@ abstract class ModelController<M extends Model> extends AdministeredItemControll
         }
     }
 
-    Map<String, Map<String, FieldDiff>> flattenDiff(final ObjectDiff objectDiff) {
+    Map<String, Map<String, FieldDiff>> flattenDiff(final ObjectDiff objectDiff, final String startingPathNodeString) {
         final Map<String, FieldDiff> mapCreated = new LinkedHashMap<>(50)
         final Map<String, FieldDiff> mapModified = new LinkedHashMap<>(50)
         final Map<String, FieldDiff> mapDeleted = new LinkedHashMap<>(50)
 
         // Make the assumption that the top level field diffs are modifications
-        flattenDiffInto(objectDiff, mapCreated, mapModified, mapDeleted, DIFF_TYPE_MODIFIED)
+        flattenDiffInto(objectDiff, mapCreated, mapModified, mapDeleted, DIFF_TYPE_MODIFIED, startingPathNodeString)
 
         final Map<String, Map<String, FieldDiff>> flattened = new HashMap<>(3)
         flattened.put("created", mapCreated)
@@ -582,12 +630,13 @@ abstract class ModelController<M extends Model> extends AdministeredItemControll
     private static int DIFF_TYPE_CREATED = 0, DIFF_TYPE_MODIFIED = 1, DIFF_TYPE_DELETED = 2
 
     private static void flattenDiffInto(
-            final ObjectDiff objectDiff,
-            final Map<String, FieldDiff> mapCreated,
-            final Map<String, FieldDiff> mapModified,
-            final Map<String, FieldDiff> mapDeleted,
-            final int diffType
-    ) {
+        final ObjectDiff objectDiff,
+        final Map<String, FieldDiff> mapCreated,
+        final Map<String, FieldDiff> mapModified,
+        final Map<String, FieldDiff> mapDeleted,
+        final int diffType,
+        final String startingPathNodeString
+                                       ) {
 
         final Map<String, FieldDiff> intoMap
         if (diffType == DIFF_TYPE_CREATED) {
@@ -606,22 +655,23 @@ abstract class ModelController<M extends Model> extends AdministeredItemControll
                 final ArrayDiff arrayDiff = (ArrayDiff) fieldDiff
 
                 for (ObjectDiff modification : arrayDiff.modified) {
-                    flattenDiffInto(modification, mapCreated, mapModified, mapDeleted, diffType == DIFF_TYPE_DELETED ? DIFF_TYPE_DELETED : DIFF_TYPE_MODIFIED)
+                    flattenDiffInto(modification, mapCreated, mapModified, mapDeleted, diffType == DIFF_TYPE_DELETED ? DIFF_TYPE_DELETED : DIFF_TYPE_MODIFIED,
+                                    startingPathNodeString)
                 }
-                for (ObjectDiff creation : (arrayDiff.created as List<ObjectDiff>)) {
-                    flattenDiffInto(creation, mapCreated, mapModified, mapDeleted, diffType == DIFF_TYPE_DELETED ? DIFF_TYPE_DELETED : DIFF_TYPE_CREATED)
+                final Map<String, FieldDiff> intoMapCreation = diffType == DIFF_TYPE_DELETED ? mapDeleted : mapCreated
+                for (CollectionDiff creation : arrayDiff.created as List<CollectionDiff>) {
+                    flattenDiffIntoMap(creation, fieldDiff, intoMapCreation, startingPathNodeString)
                 }
-                for (ObjectDiff deletion : (arrayDiff.deleted as List<ObjectDiff>)) {
-                    flattenDiffInto(deletion, mapCreated, mapModified, mapDeleted, DIFF_TYPE_CREATED)
+                for (CollectionDiff deletion : arrayDiff.deleted as List<CollectionDiff>) {
+                    flattenDiffIntoMap(deletion, fieldDiff, mapDeleted, startingPathNodeString)
                 }
             } else {
-                flattenDiffIntoMap(fieldDiff, intoMap)
+                flattenDiffIntoMap(fieldDiff, intoMap, startingPathNodeString)
             }
-
         }
     }
 
-    private static void flattenDiffIntoMap(final FieldDiff fieldDiff, final Map<String, FieldDiff> intoMap) {
+    private static void flattenDiffIntoMap(final FieldDiff fieldDiff, final Map<String, FieldDiff> intoMap, final String startingPathNodeString) {
         final String pathString
 
         if (fieldDiff.rhsDiffableItem != null) {
@@ -634,11 +684,40 @@ abstract class ModelController<M extends Model> extends AdministeredItemControll
 
         // Make the path's model identifier the same so paths from different
         // models are comparable
-        final Path path = new Path(pathString)
+        // Root the path starting from the startingPathNodeString as the context item
+        final Path path = new Path(pathString).trimUntil(startingPathNodeString)
 
         final Path.PathNode firstNode = path.nodes[0]
         firstNode.modelIdentifier = '--------'
-        path.setNodes(path.nodes)
+        path.updatePathString()
+
+        intoMap.put(path.toString(), fieldDiff)
+    }
+
+    private static void flattenDiffIntoMap(final CollectionDiff collectionDiff, final FieldDiff fieldDiff, final Map<String, FieldDiff> intoMap,
+                                           final String startingPathNodeString) {
+        final String pathString = collectionDiff.diffIdentifier
+
+        // Make the path's model identifier the same so paths from different
+        // models are comparable
+        // Root the path starting from the startingPathNodeString as the context item
+
+        System.out.println("flattenDiffIntoMap "+pathString+" trimUntil "+startingPathNodeString)
+
+        final Path path
+        try {
+            path = new Path(pathString).trimUntil(startingPathNodeString)
+        }
+        catch (IllegalArgumentException iae) {
+            iae.printStackTrace()
+
+            System.err.println(fieldDiff.toString())
+            throw new HttpStatusException(HttpStatus.INTERNAL_SERVER_ERROR, iae.toString())
+        }
+
+        final Path.PathNode firstNode = path.nodes[0]
+        firstNode.modelIdentifier = '--------'
+        path.updatePathString()
 
         intoMap.put(path.toString(), fieldDiff)
     }
@@ -696,4 +775,1063 @@ abstract class ModelController<M extends Model> extends AdministeredItemControll
     protected M saveModel(M model) {
         modelContentRepository.saveWithContent(model)
     }
+
+    protected ModelVersionDTO latestModelVersion(UUID id) {
+        final List<Model> allModels = populateVersionTree(id, false, null)
+
+        if (allModels.size() == 0) {
+            new ModelVersionDTO(modelVersion: FieldConstants.DEFAULT_MODEL_VERSION)
+        }
+
+        ModelVersion highestVersion = null
+
+        for (int m = 0; m < allModels.size(); m++) {
+            final Model givenModel = allModels.get(m)
+            final ModelVersion modelVersion = givenModel.modelVersion
+            if (modelVersion == null) {
+                continue
+            }
+
+            if (highestVersion == null) {
+                highestVersion = modelVersion
+                continue
+            }
+
+            if (modelVersion > highestVersion) {
+                highestVersion = modelVersion
+            }
+        }
+
+        if (highestVersion == null) {
+            log.warn("There are no versioned models for data model :$id")
+        }
+
+        return new ModelVersionDTO(modelVersion: highestVersion ?: ModelVersion.from(FieldConstants.DEFAULT_MODEL_VERSION))
+    }
+
+    protected ModelVersionedRefDTO latestFinalisedModel(UUID id) {
+        final List<Model> allModels = populateVersionTree(id, false, null)
+
+        if (allModels.size() == 0) {
+            throw new HttpStatusException(HttpStatus.NOT_FOUND, "There are no models")
+        }
+
+        Model highestVersionModel = null
+
+        for (int m = 0; m < allModels.size(); m++) {
+            final Model givenModel = allModels.get(m)
+            final ModelVersion modelVersion = givenModel.modelVersion
+            if (modelVersion == null) {
+                continue
+            }
+
+            if (highestVersionModel == null) {
+                highestVersionModel = givenModel
+                continue
+            }
+
+            if (modelVersion > highestVersionModel.modelVersion) {
+                highestVersionModel = givenModel
+            }
+        }
+
+        if (highestVersionModel == null) {
+            throw new HttpStatusException(HttpStatus.NOT_FOUND, "There are no versioned models")
+        }
+
+        return new ModelVersionedRefDTO(id: highestVersionModel.id, domainType: highestVersionModel.domainType, label: highestVersionModel.label,
+                                        branch: highestVersionModel.branchName, branchName: highestVersionModel.branchName,
+                                        modelVersion: highestVersionModel.modelVersion?.toString(), modelVersionTag: highestVersionModel.modelVersionTag,
+                                        documentationVersion: highestVersionModel.documentationVersion, displayName: highestVersionModel.pathModelIdentifier)
+    }
+
+    protected M commonAncestor(UUID id, UUID other_model_id) {
+        final M left = show(id)
+        if (!left) {
+            throw new HttpStatusException(HttpStatus.NOT_FOUND, "No data model found for id [${left.id.toString()}]")
+        }
+        final M right = show(other_model_id)
+        if (!right) {
+            throw new HttpStatusException(HttpStatus.NOT_FOUND, "No data model found for id [${right.id.toString()}]")
+        }
+
+        return findCommonAncestorBetweenModels(left, right)
+    }
+
+    protected M currentMainBranch(UUID id) {
+
+        // Like Highlander, there can be only one
+        // main/draft version
+        // and it downstream
+
+        final List<Model> allModels = populateVersionTree(id, true, null)
+
+        for (int m = allModels.size() - 1; m >= 0; m--) {
+            final Model givenModel = allModels.get(m)
+            if (givenModel.branchName == Model.DEFAULT_BRANCH_NAME && !givenModel.finalised) {
+                return givenModel as M
+            }
+        }
+
+        throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "There is no main draft model")
+    }
+
+    protected List<ModelVersionedRefDTO> simpleModelVersionTree(UUID id, @Nullable Boolean branchesOnly) {
+
+        branchesOnly = branchesOnly ?: false
+
+        final List<Model> allModels = populateVersionTree(id, branchesOnly, null)
+
+        // Create object DTOs
+
+        final ArrayList<ModelVersionedRefDTO> simpleModelVersionTreeList = new ArrayList<>(allModels.size())
+
+        allModels.forEach {Model model ->
+
+            if (!branchesOnly || !model.finalised) {
+                simpleModelVersionTreeList.add(
+                    new ModelVersionedRefDTO(id: model.id, domainType: model.domainType, label: model.label, model: model.owner.id, branch: model.branchName,
+                                             branchName: model.branchName,
+                                             modelVersion: model.modelVersion?.toString(), modelVersionTag: model.modelVersionTag,
+                                             documentationVersion: model.documentationVersion,
+                                             displayName: model.pathModelIdentifier))
+            }
+        }
+
+        simpleModelVersionTreeList
+    }
+
+    protected List<ModelVersionedWithTargetsRefDTO> modelVersionTree(UUID id) {
+
+        final Map<UUID, Map<String, Boolean>> flags = [:]
+        final List<Model> allModels = populateVersionTree(id, false, flags)
+
+        // Create object DTOs
+
+        final ArrayList<ModelVersionedWithTargetsRefDTO> modelVersionTreeList = new ArrayList<>(allModels.size())
+
+        for (Model model : allModels) {
+            final ModelVersionedWithTargetsRefDTO modelVersionedWithTargetsRefDTO = new ModelVersionedWithTargetsRefDTO(id: model.id, branch: model.branchName,
+                                                                                                                        branchName: model.branchName,
+                                                                                                                        modelVersion: model.modelVersion?.toString(),
+                                                                                                                        modelVersionTag: model.modelVersionTag,
+                                                                                                                        documentationVersion: model.documentationVersion,
+                                                                                                                        displayName: model.pathModelIdentifier,
+                                                                                                                        domainType: model.domainType)
+
+            // Have any flags been set during recursion?
+            final Map<String, Boolean> modelFlags = flags.get(modelVersionedWithTargetsRefDTO.id)
+
+            if (modelFlags != null) {
+                Boolean isNewBranchModelVersion = modelFlags.get("isNewBranchModelVersion")
+                Boolean isNewFork = modelFlags.get("isNewFork")
+
+                if (isNewBranchModelVersion != null && isNewBranchModelVersion) {
+                    modelVersionedWithTargetsRefDTO.isNewBranchModelVersion = true
+                } else if (isNewFork != null && isNewFork) {
+                    modelVersionedWithTargetsRefDTO.isNewFork = true
+                }
+            }
+
+            // Add in targets
+
+            if (model.versionLinks != null && !model.versionLinks.isEmpty()) {
+                for (VersionLink childVersion : model.versionLinks) {
+                    final UUID targetModelId = childVersion.targetModelId
+                    if (targetModelId == null) {
+                        continue
+                    }
+
+                    final VersionLinkTargetDTO versionLinkTargetDTO = new VersionLinkTargetDTO(id: targetModelId, description: childVersion.description)
+
+                    modelVersionedWithTargetsRefDTO.targets.add(versionLinkTargetDTO)
+                }
+            }
+
+            modelVersionTreeList.add(modelVersionedWithTargetsRefDTO)
+        }
+
+        modelVersionTreeList
+    }
+
+    protected MergeDiffDTO mergeDiff(@NonNull UUID id, @NonNull UUID otherId) {
+        final M dataModelOne = modelContentRepository.findWithContentById(id)
+        ErrorHandler.handleErrorOnNullObject(HttpStatus.NOT_FOUND, dataModelOne, "item with $id not found")
+
+        final M dataModelTwo = modelContentRepository.findWithContentById(otherId)
+        ErrorHandler.handleErrorOnNullObject(HttpStatus.NOT_FOUND, dataModelTwo, "item with $otherId not found")
+
+        accessControlService.checkRole(Role.READER, dataModelOne)
+        accessControlService.checkRole(Role.READER, dataModelTwo)
+
+        // The model to merge into must not be finalised
+        if (dataModelTwo.finalised) {
+            throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "MS03 The target model must not be finalised")
+        }
+
+        final M commonAncestor = findCommonAncestorBetweenModels(dataModelOne, dataModelTwo)
+
+        dataModelOne.setAssociations()
+        dataModelTwo.setAssociations()
+        commonAncestor.setAssociations()
+
+        connectFacets(commonAncestor)
+        connectFacets(dataModelOne)
+        connectFacets(dataModelTwo)
+
+        pathRepository.readParentItems(dataModelOne)
+        dataModelOne.updatePath()
+
+        pathRepository.readParentItems(dataModelTwo)
+        dataModelTwo.updatePath()
+
+        // For a merge, there are two diffs between the common ancestor and model being merged
+
+        final ObjectDiff objectDiffOne = commonAncestor.diff(dataModelOne)
+        final ObjectDiff objectDiffTwo = commonAncestor.diff(dataModelTwo)
+
+        // Remove branchName differences since these are merges of branches
+        for (ObjectDiff objectDiff : ([objectDiffOne, objectDiffTwo] as List<ObjectDiff>)) {
+            final ArrayList<FieldDiff> diffsToRemove = new ArrayList<>(2)
+            for (fieldDiff in objectDiff.diffs) {
+                if (fieldDiff.name == 'branchName') {
+                    diffsToRemove.add(fieldDiff)
+                }
+            }
+            objectDiff.diffs.removeAll(diffsToRemove)
+        }
+
+        // recurse down through each diff and create a map of Path-> FieldDiff
+
+        Map<String, Map<String, FieldDiff>> flattenedDiffOne = flattenDiff(objectDiffOne, dataModelOne.pathNodeString)
+        Map<String, Map<String, FieldDiff>> flattenedDiffTwo = flattenDiff(objectDiffTwo, dataModelTwo.pathNodeString)
+
+        // Collate the set of all paths used as keys
+
+        final Map<String, FieldDiff> flattenedDiffOneCreated = flattenedDiffOne.get('created')
+        final Map<String, FieldDiff> flattenedDiffOneModified = flattenedDiffOne.get('modified')
+        final Map<String, FieldDiff> flattenedDiffOneDeleted = flattenedDiffOne.get('deleted')
+
+        final Map<String, FieldDiff> flattenedDiffTwoCreated = flattenedDiffTwo.get('created')
+        final Map<String, FieldDiff> flattenedDiffTwoModified = flattenedDiffTwo.get('modified')
+        final Map<String, FieldDiff> flattenedDiffTwoDeleted = flattenedDiffTwo.get('deleted')
+
+        // Remove changes from the common ancestor that are common to both models
+
+        flattenedDiffTwoCreated.keySet().forEach {
+            flattenedDiffOneCreated.remove(it)
+        }
+
+        flattenedDiffTwoDeleted.keySet().forEach {
+            flattenedDiffOneDeleted.remove(it)
+        }
+
+        // Remove any 'creations' that are already in the target model
+
+        flattenedDiffOneCreated.keySet().forEach {
+            flattenedDiffTwoCreated.remove(it)
+        }
+
+        final List<Map<String, FieldDiff>> flattenedDiffOneMapList = [flattenedDiffOneCreated, flattenedDiffOneModified, flattenedDiffOneDeleted]
+        final List<Map<String, FieldDiff>> flattenedDiffTwoMapList = [flattenedDiffTwoCreated, flattenedDiffTwoModified, flattenedDiffTwoDeleted]
+
+        final Set<String> allPaths = new LinkedHashSet<>()
+        for (Map<String, FieldDiff> pathToFieldDiff : flattenedDiffOneMapList + flattenedDiffTwoMapList) {
+            final Set keys = pathToFieldDiff.keySet()
+            allPaths.addAll(keys)
+        }
+
+        List<Path.PathNode> pathNodes = []
+
+        AdministeredItem node = dataModelOne
+        pathNodes.add(0, new Path.PathNode(prefix: node.pathPrefix, identifier: node.pathIdentifier, modelIdentifier: node.pathModelIdentifier))
+
+        final Path path = new Path(pathNodes)
+        final String sourcePath = path.toString()
+
+        final List<MergeFieldDiffDTO> diffs = []
+        final MergeDiffDTO mergeDiffDTO = new MergeDiffDTO(sourceId: dataModelOne.id, targetId: dataModelTwo.id, path: sourcePath, label: dataModelOne.label, diffs: diffs)
+
+        // With ancestor = common ancestor, one = source of merge, two = target of merge
+        // The conflicts are detected like this:
+
+        // 1. Deletion conflict rules
+        // deletions are a conflict when a deletion from one is not matched by a deletion in two
+        // All descendant paths must be flagged too
+
+        // 2. Modification conflict rules
+        // for each key, compare what needs to be done to merge
+        // modifications are only in conflict when the value of the ancestor, branch one, branch two all have
+        // different values e.g. there are 3 distinct values
+        // For each distinct path, look up the value held in each of the three places and add it to a set
+        // if the set has 3 values, there is a conflict, otherwise it a simple change
+
+        final String targetPrefix = dataModelTwo.pathPrefix
+        final String targetPathIdentifier = dataModelTwo.pathIdentifier
+        final String targetPathModelIdentifier = dataModelTwo.pathModelIdentifier
+
+        // Deletion conflicts
+        // For all deletions in one, find all descendants are not deleted in two
+
+        final String[] flattenedDiffOneDeletedPaths = flattenedDiffOneDeleted.keySet().toArray(new String[0])
+        final String[] flattenedDiffTwoDeletedPaths = flattenedDiffTwoDeleted.keySet().toArray(new String[0])
+        final String[] flattenedDiffTwoCreatedPaths = flattenedDiffTwoCreated.keySet().toArray(new String[0])
+        final String[] flattenedDiffTwoModifiedPaths = flattenedDiffTwoModified.keySet().toArray(new String[0])
+
+        List<String> haveDeleted = []
+        for (String deletionInOne : flattenedDiffOneDeletedPaths) {
+            boolean deletedAsWell = false
+            for (String deletionInTwo : flattenedDiffTwoDeletedPaths) {
+                if (deletionInOne == deletionInTwo) {
+                    deletedAsWell = true
+                    break
+                }
+            }
+
+            if (!deletedAsWell) {
+
+                // Deletion / existence conflict
+
+                if (!haveDeleted.contains(deletionInOne)) {
+
+                    allPaths.remove(deletionInOne)
+
+                    final FieldDiff conflictingFieldDiff = flattenedDiffOneDeleted.get(deletionInOne)
+                    final String fieldName = conflictingFieldDiff.name
+
+                    Path ancestorBasedPath = new Path(deletionInOne)
+                    ancestorBasedPath.nodes.get(0).tap {
+                        prefix = targetPrefix
+                        identifier = targetPathIdentifier
+                        modelIdentifier = targetPathModelIdentifier
+                    }
+                    ancestorBasedPath = new Path(ancestorBasedPath.nodes)
+
+                    final MergeFieldDiffDTO mergeFieldDiffDTO = new MergeFieldDiffDTO(fieldName: fieldName, sourceValue: null, targetValue: null,
+                                                                                      commonAncestorValue: null, isMergeConflict: true, _type: "deletion",
+                                                                                      path: ancestorBasedPath)
+                    diffs.add(mergeFieldDiffDTO)
+                }
+
+                // Find descendants that would be deleted
+                for (String otherDeletionInOne : flattenedDiffOneDeletedPaths) {
+                    if (otherDeletionInOne.startsWith(deletionInOne + '|') && otherDeletionInOne != deletionInOne) {
+
+                        final FieldDiff conflictingFieldDiff = flattenedDiffOneDeleted.get(otherDeletionInOne)
+                        final String fieldName = conflictingFieldDiff.name
+
+                        String descendantFragment = otherDeletionInOne.substring(deletionInOne.length())
+
+                        StringTokenizer st = new StringTokenizer(descendantFragment, '|')
+                        String descendantPath = deletionInOne
+                        while (st.hasMoreTokens()) {
+
+                            descendantPath += '|' + st.nextToken()
+
+                            // Done it already
+                            if (haveDeleted.contains(descendantPath)) {
+                                continue
+                            }
+                            // Will be done later
+                            if (st.hasMoreTokens() && allPaths.contains(descendantPath)) {
+                                continue
+                            }
+
+                            allPaths.remove(descendantPath)
+                            haveDeleted.add(descendantPath)
+
+                            Path ancestorBasedPath = new Path(descendantPath)
+                            ancestorBasedPath.nodes.get(0).tap {
+                                prefix = targetPrefix
+                                identifier = targetPathIdentifier
+                                modelIdentifier = targetPathModelIdentifier
+                            }
+                            ancestorBasedPath = new Path(ancestorBasedPath.nodes)
+
+                            final MergeFieldDiffDTO mergeFieldDiffDTO = new MergeFieldDiffDTO(fieldName: fieldName, sourceValue: null, targetValue: null,
+                                                                                              commonAncestorValue: null, isMergeConflict: true, _type: "deletion",
+                                                                                              path: ancestorBasedPath)
+                            diffs.add(mergeFieldDiffDTO)
+                        }
+                    }
+                }
+                for (String modificationInTwo : flattenedDiffTwoModifiedPaths) {
+                    if (modificationInTwo.startsWith(deletionInOne + '|')) {
+
+                        final FieldDiff conflictingFieldDiff = flattenedDiffTwoModified.get(modificationInTwo)
+                        final String fieldName = conflictingFieldDiff.name
+
+                        String descendantFragment = modificationInTwo.substring(deletionInOne.length())
+
+                        StringTokenizer st = new StringTokenizer(descendantFragment, '|')
+                        String descendantPath = deletionInOne
+                        while (st.hasMoreTokens()) {
+
+                            descendantPath += '|' + st.nextToken()
+
+                            // Done it already
+                            if (haveDeleted.contains(descendantPath)) {
+                                continue
+                            }
+                            // Will be done later
+                            if (st.hasMoreTokens() && allPaths.contains(descendantPath)) {
+                                continue
+                            }
+
+                            allPaths.remove(descendantPath)
+                            haveDeleted.add(descendantPath)
+
+                            Path ancestorBasedPath = new Path(descendantPath)
+                            ancestorBasedPath.nodes.get(0).tap {
+                                prefix = targetPrefix
+                                identifier = targetPathIdentifier
+                                modelIdentifier = targetPathModelIdentifier
+                            }
+                            ancestorBasedPath = new Path(ancestorBasedPath.nodes)
+
+                            final MergeFieldDiffDTO mergeFieldDiffDTO = new MergeFieldDiffDTO(fieldName: fieldName, sourceValue: null, targetValue: null,
+                                                                                              commonAncestorValue: null, isMergeConflict: true, _type: "deletion",
+                                                                                              path: ancestorBasedPath)
+                            diffs.add(mergeFieldDiffDTO)
+                        }
+                    }
+                }
+                for (String creationInTwo : flattenedDiffTwoCreatedPaths) {
+                    if (creationInTwo.startsWith(deletionInOne + '|')) {
+
+                        final FieldDiff conflictingFieldDiff = flattenedDiffTwoCreated.get(creationInTwo)
+                        final String fieldName = conflictingFieldDiff.name
+
+                        String descendantFragment = creationInTwo.substring(deletionInOne.length())
+
+                        StringTokenizer st = new StringTokenizer(descendantFragment, '|')
+                        String descendantPath = deletionInOne
+                        while (st.hasMoreTokens()) {
+
+                            descendantPath += '|' + st.nextToken()
+
+                            // Done it already
+                            if (haveDeleted.contains(descendantPath)) {
+                                continue
+                            }
+                            // Will be done later
+                            if (st.hasMoreTokens() && allPaths.contains(descendantPath)) {
+                                continue
+                            }
+
+                            allPaths.remove(descendantPath)
+                            haveDeleted.add(descendantPath)
+
+                            Path ancestorBasedPath = new Path(descendantPath)
+                            ancestorBasedPath.nodes.get(0).tap {
+                                prefix = targetPrefix
+                                identifier = targetPathIdentifier
+                                modelIdentifier = targetPathModelIdentifier
+                            }
+                            ancestorBasedPath = new Path(ancestorBasedPath.nodes)
+
+                            final MergeFieldDiffDTO mergeFieldDiffDTO = new MergeFieldDiffDTO(fieldName: fieldName, sourceValue: null, targetValue: null,
+                                                                                              commonAncestorValue: null, isMergeConflict: true, _type: "deletion",
+                                                                                              path: ancestorBasedPath)
+                            diffs.add(mergeFieldDiffDTO)
+                        }
+                    }
+                }
+            }
+        }
+
+        // Changes
+        for (String key : allPaths) {
+            FieldDiff fieldDiffOne = null
+            String _type = 'modification'
+
+            lookingInOne:
+            for (Map<String, FieldDiff> pathToFieldDiff : flattenedDiffOneMapList) {
+                final foundFieldDiff = pathToFieldDiff.get(key)
+                if (foundFieldDiff != null) {
+                    fieldDiffOne = foundFieldDiff
+                    if (pathToFieldDiff == flattenedDiffOneCreated) {
+                        _type = 'creation'
+                    } else if (pathToFieldDiff == flattenedDiffOneDeleted) {
+                        _type = 'deletion'
+                    }
+                    break lookingInOne
+                }
+            }
+
+            FieldDiff fieldDiffTwo = null
+            lookingInTwo:
+            for (Map<String, FieldDiff> pathToFieldDiff : flattenedDiffTwoMapList) {
+                final foundFieldDiff = pathToFieldDiff.get(key)
+                if (foundFieldDiff != null) {
+                    fieldDiffTwo = foundFieldDiff
+                    break lookingInTwo
+                }
+            }
+
+            // Find the common ancestor version
+            // In the FieldDiff lhs is the value object from the commonAncestor, rhs is a branch
+
+            final Object fieldOneValue, fieldTwoValue, ancestorValue
+            final String fieldName
+
+            // Establish the ancestorValue first, since it is the backstop value
+
+            if (fieldDiffOne != null) {
+                ancestorValue = fieldDiffOne.left
+                fieldName = fieldDiffOne.name
+            } else if (fieldDiffTwo != null) {
+                ancestorValue = fieldDiffTwo.left
+                fieldName = fieldDiffTwo.name
+            } else {
+                ancestorValue = null
+                fieldName = null
+            }
+
+            // If there is a change, record the value
+            // or else it is the same as the ancestor value
+
+            if (fieldDiffOne != null) {
+                fieldOneValue = fieldDiffOne.right
+            } else {
+                fieldOneValue = ancestorValue
+            }
+
+            if (fieldDiffTwo != null) {
+                fieldTwoValue = fieldDiffTwo.right
+            } else {
+                fieldTwoValue = ancestorValue
+            }
+
+            // Changes to do with versioning itself are not wanted here
+            if (fieldName == 'finalised' || fieldName == 'dateFinalised' || fieldName == 'pathModelIdentifier' || fieldName == 'modelVersionTag') {
+                continue
+            }
+
+            // If a fieldValueOne or fieldValueTwo value do not exist and the ancestor value does, they are
+            // no different from the ancestor value
+            final HashSet<Object> values = [fieldOneValue, fieldTwoValue, ancestorValue]
+
+            final boolean isMergeConflict = values.size() == 3
+
+            // Because the target branch is branch two, we are only interested in
+            // changes or conflicts coming from the source branch (branch one)
+            // anything that is not a conflict from branch two is a no-op
+            //                 | ---------------(Branch Two)-->
+            //  (ancestor) --> | ---(Branch One)----^
+            // The diffs are replayed from the common ancestor, on top of the target branch, so paths must be in terms of the target branch
+            // There's a side effect of changing a label: paths change
+
+            if (!isMergeConflict && fieldDiffOne == null) {
+                continue
+            }
+
+            // Is it actually a change in the target?
+            if (fieldOneValue != null && fieldTwoValue != null && fieldOneValue == fieldTwoValue) {
+                continue
+            }
+
+            Path ancestorBasedPath = new Path(key)
+            ancestorBasedPath.nodes.get(0).tap {
+                prefix = targetPrefix
+                identifier = targetPathIdentifier
+                modelIdentifier = targetPathModelIdentifier
+            }
+            ancestorBasedPath = new Path(ancestorBasedPath.nodes)
+
+            final MergeFieldDiffDTO mergeFieldDiffDTO = new MergeFieldDiffDTO(fieldName: fieldName, sourceValue: fieldOneValue, targetValue: fieldTwoValue,
+                                                                              commonAncestorValue: ancestorValue, isMergeConflict: isMergeConflict, _type: _type,
+                                                                              path: ancestorBasedPath)
+
+            diffs.add(mergeFieldDiffDTO)
+        }
+        return mergeDiffDTO
+    }
+
+    @ExecuteOn(TaskExecutors.BLOCKING)
+    protected M mergeInto(@NonNull UUID id, @NonNull UUID otherId, @Body @Nullable MergeIntoDTO mergeIntoDTO) {
+        if (mergeIntoDTO.patch.sourceId != id) {
+            throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, 'Source model id passed in request body does not match source model id in URI.')
+        }
+        if (mergeIntoDTO.patch.targetId != otherId) {
+            throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, 'Target model id passed in request body does not match target model id in URI.')
+        }
+
+        M sourceModel = modelContentRepository.findWithContentById(id)
+        if (sourceModel == null) {
+            throw new HttpStatusException(HttpStatus.NOT_FOUND, id.toString())
+        }
+
+        M targetModel = modelContentRepository.findWithContentById(otherId)
+        if (targetModel == null) {
+            throw new HttpStatusException(HttpStatus.NOT_FOUND, targetModel.toString())
+        }
+
+        // The model to merge into must not be finalised
+        if (targetModel.finalised) {
+            throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "MS03 The target model must not be finalised")
+        }
+
+        accessControlService.checkRole(Role.READER, sourceModel)
+        accessControlService.checkRole(Role.EDITOR, targetModel)
+
+        // Do merge here
+        // SEE: grails ModelService.mergeObjectPatchDataIntoModel
+
+        final ObjectPatchDataDTO objectPatchDataDTO = mergeIntoDTO.patch
+
+        if (objectPatchDataDTO.patches == null || objectPatchDataDTO.patches.size() == 0) {
+            throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, 'No patch data to merge into ' + targetModel.id)
+        }
+
+        final String changeNotice = mergeIntoDTO.changeNotice
+
+        final Map<UUID, Boolean> addedChangeNotice = [:]
+
+        if (changeNotice) {
+            // add change notice edit for current user
+            editController.createEdit(targetModel, EditType.CHANGENOTICE, changeNotice)
+            addedChangeNotice.put(targetModel.id, true)
+        }
+
+        List<FieldPatchDataDTO> sortedFieldPatchDataForMerging = getSortedFieldPatchDataForMerging(objectPatchDataDTO)
+
+        sortedFieldPatchDataForMerging.each {fieldPatch ->
+            switch (fieldPatch._type) {
+                case 'creation':
+                    return processCreationPatchIntoModel(fieldPatch, targetModel, sourceModel, changeNotice, addedChangeNotice)
+                case 'deletion':
+                    return
+                case 'modification':
+                    return processModificationPatchIntoModel(fieldPatch, targetModel, sourceModel, changeNotice, addedChangeNotice)
+                default:
+                    System.err.println('Unknown field patch type ' + fieldPatch._type)
+            }
+        }
+
+        List<FieldPatchDataDTO> sortedFieldPatchDataForMergingDeletion = getSortedFieldPatchDataForMergingDeletion(objectPatchDataDTO)
+
+        sortedFieldPatchDataForMergingDeletion.reverse().each {fieldPatch ->
+            switch (fieldPatch._type) {
+                case 'deletion':
+                    return processDeletionPatchIntoModel(fieldPatch, targetModel, sourceModel, changeNotice, addedChangeNotice)
+            }
+        }
+
+        if (mergeIntoDTO.deleteBranch) {
+
+            // TODO:
+            // Check permissions
+            // delete the model
+        }
+
+        administeredItemRepository.update(targetModel)
+
+        targetModel
+    }
+
+    List<FieldPatchDataDTO> getSortedFieldPatchDataForMerging(ObjectPatchDataDTO objectPatchData) {
+        /*
+          We have to process modifications in after everything else incase the modifications require something to have been created
+          Process creations before deletions, that way any deletions will automatically take care of any links to potentially created objects
+           */
+        objectPatchData.patches.sort {l, r ->
+            if (l._type == r._type) {return 0}
+            return l <=> r
+        }
+    }
+
+    List<FieldPatchDataDTO> getSortedFieldPatchDataForMergingDeletion(ObjectPatchDataDTO objectPatchData) {
+        /*
+            We process leaves first and delete towards the root
+         */
+        objectPatchData.patches.sort {l, r ->
+            return l.path.toString() <=> r.path.toString()
+        }
+    }
+
+    void processCreationPatchIntoModel(FieldPatchDataDTO creationPatch, M targetModel, M sourceModel, final String changeNotice, final Map<UUID, Boolean> addedChangeNotice) {
+
+        // Check whether the target path already exists - it is possible that it has been created by re-referencing during creation
+        // of reference types, and that would not be an error
+        try {
+            AdministeredItem checkForExistenceAdministeredItemTarget = pathRepository.findResourcesByPathFromRootResource(targetModel, creationPatch.path)
+            if (checkForExistenceAdministeredItemTarget != null) {
+                // no op
+                return
+            }
+        }
+        catch (Exception ignored) {
+            throw new HttpStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to create path for ${creationPatch.path.toString()}")
+        }
+
+        // Find the Item referenced by the creationPatch in the source model
+        // and the parent item to create it in, in the target model using their paths
+
+        // findResourcesByPathFromRootResource throws an exception if the path is not found
+        // The source path
+        final AdministeredItem administeredItemSource = getWithContents(pathRepository.findResourcesByPathFromRootResource(sourceModel, creationPatch.path))
+
+        // The target parent path
+        AdministeredItem administeredItemTargetParent = null
+
+        try {
+            administeredItemTargetParent = pathRepository.findResourcesByPathFromRootResource(targetModel, creationPatch.path.parent)
+
+            if (administeredItemTargetParent == null) {
+                processCreationPatchIntoModel(creationPatch.getParentPathPatch(), targetModel, sourceModel, changeNotice, addedChangeNotice)
+                // The target's parent should have been created by this point, if not this will throw an error
+                try {
+                    administeredItemTargetParent = pathRepository.findResourcesByPathFromRootResource(targetModel, creationPatch.path.parent)
+                }
+                catch (Exception ignoredAgain) {
+                    throw new HttpStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to create path for ${creationPatch.path.toString()}")
+                }
+                if (administeredItemTargetParent == null) {
+                    throw new HttpStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to create path for ${creationPatch.path.toString()}")
+                }
+            }
+        }
+        catch (Exception ignored) {
+            throw new HttpStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to create path for ${creationPatch.path.toString()}")
+        }
+
+        // Make a copy of the AdministeredItem from the source, then attach the copy to the target parent
+        final AdministeredItem clonedAdministeredItem = administeredItemSource.clone()
+
+        // reset any properties to do with versioning or branches etc and, of course, the Id as it will
+        // need a new one
+
+        if (clonedAdministeredItem instanceof Model) {
+            final Model clonedAdministeredItemAsModel = (Model) clonedAdministeredItem
+
+            clonedAdministeredItemAsModel.finalised = false
+            clonedAdministeredItemAsModel.dateFinalised = null
+            clonedAdministeredItemAsModel.modelVersion = null
+            clonedAdministeredItemAsModel.modelVersionTag = null
+            clonedAdministeredItemAsModel.branchName = sourceModel.branchName
+            clonedAdministeredItemAsModel.versionLinks = []
+        }
+
+        clonedAdministeredItem.updateCreationProperties()
+        clonedAdministeredItem.catalogueUser = accessControlService.getUser()
+        clonedAdministeredItem.parent = administeredItemTargetParent
+
+        // Make an initial save here, so that child items may have something to reference as a parent
+
+        pathRepository.readParentItems(clonedAdministeredItem)
+        clonedAdministeredItem.updatePath()
+        clonedAdministeredItem.updateBreadcrumbs()
+        AdministeredItemRepository simpleRepositoryToUse = pathRepository.getRepository(clonedAdministeredItem)
+        final AdministeredItem savedClonedAdministeredItem = (AdministeredItem) simpleRepositoryToUse.save(clonedAdministeredItem)
+
+        /*
+         Is this clonedAdministeredItem referencing something within the scope of its own 'versionable' (Versioned folder, Data model)?
+         If so, it must reference an equivalent in the target model rather than the reference it has to a source item
+
+         These kinds of things that reference other things must implement ItemReferencer.
+
+         E.g.
+         DataType references -> Model, DataClass
+         SemanticLink relations
+         CodeSet
+         VersionLink
+         DataClasses can extend other classes
+
+         */
+
+        if (savedClonedAdministeredItem instanceof ItemReferencer) {
+
+            // This works by asking ItemReferencer for the list of items that it references
+            // Using the path, ask whether the item being referenced is within the scope
+            // of what is being merged
+            // If so, clone those and ask the ItemReferencer to update its references to the
+            // cloned ones
+            ItemReferencer itemReferencer = (ItemReferencer) savedClonedAdministeredItem
+            List<ItemReference> referencedItems = itemReferencer.itemReferences
+
+            // Resolve these to a list of paths
+            List<Path> pathsToReferencedItems = pathRepository.resolveItemReferences(referencedItems)
+
+            // Are any of these paths inside the source model?
+            final Map<UUID, ItemReference> toReplace = [:]
+            for (int p = 0; p < pathsToReferencedItems.size(); p++) {
+                Path pathToReferencedItem = pathsToReferencedItems.get(p)
+
+                Path pathToReferencedItemFromSource = pathToReferencedItem.trimUntil(sourceModel.pathNodeString)
+
+                // This is the source item if found
+                Item item = pathToReferencedItem.findNodeItem(sourceModel.id)
+
+                if (item != null) {
+
+                    // Yes, this reference is the source model
+                    // It is in the target model?
+
+                    Path pathToReferencedItemFromTarget = pathToReferencedItem.trimUntil(targetModel.pathNodeString)
+
+                    //System.out.println("targetModel.pathNodeString "+targetModel.pathNodeString)
+                    //System.out.println("pathToReferencedItemFromTarget "+pathToReferencedItemFromTarget.toString())
+
+                    AdministeredItem targetToReferencedItem
+                    try {
+                        targetToReferencedItem = pathRepository.findResourcesByPathFromRootResource(targetModel, pathToReferencedItemFromTarget)
+
+                        if (targetToReferencedItem == null) {
+                            // No? Needs to be created then
+                            processCreationPatchIntoModel(new FieldPatchDataDTO(path: pathToReferencedItemFromSource, _type: creationPatch._type), targetModel,
+                                                          sourceModel, changeNotice, addedChangeNotice)
+                            try {
+                                targetToReferencedItem = pathRepository.findResourcesByPathFromRootResource(targetModel, pathToReferencedItemFromTarget)
+                            }
+                            catch (Exception ignoredOnceMore) {
+                                ignoredOnceMore.printStackTrace()
+                                throw new HttpStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to create path for ${pathToReferencedItemFromTarget.toString()}")
+                            }
+                            if (targetToReferencedItem == null) {
+                                throw new HttpStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to create path for ${pathToReferencedItemFromTarget.toString()}")
+                            }
+                        }
+                    }
+                    catch (Exception ignored) {
+                        ignored.printStackTrace()
+                        throw new HttpStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to create path for ${pathToReferencedItemFromTarget.toString()}")
+                    }
+
+                    // Resolve the source item from the path so it can be swapped out
+                    AdministeredItem sourceOfReferencedItem
+
+                    try {
+                        sourceOfReferencedItem = pathRepository.findResourcesByPathFromRootResource(sourceModel, pathToReferencedItemFromSource)
+                        if (sourceOfReferencedItem == null) {
+                            throw new HttpStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to find path for ${pathToReferencedItemFromSource.toString()}")
+                        }
+                    }
+                    catch (Exception ignored) {
+                        throw new HttpStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to find path for ${pathToReferencedItemFromSource.toString()}")
+                    }
+
+                    // Record a map of the ItemReferences the ItemReferencer will need to update to use the new reference
+                    toReplace.put(sourceOfReferencedItem.id, ItemReference.from(targetToReferencedItem))
+                }
+            }
+
+            // Ask the ItemReferencer to update to use the cloned items
+            itemReferencer.replaceItemReferences(toReplace)
+
+            // Then for each item, call update
+
+            toReplace.values().forEach {ItemReference itemReference ->
+
+                if (itemReference.theItem && itemReference.theItem instanceof AdministeredItem) {
+                    AdministeredItemCacheableRepository administeredItemCacheableRepository =
+                        administeredItemContentRepository.getRepository((AdministeredItem) itemReference.theItem)
+                    administeredItemCacheableRepository.update((AdministeredItem) itemReference.theItem)
+                }
+            }
+        }
+
+        // Record edits
+        // Put a change notice once up front for all local changes
+        if (changeNotice && !addedChangeNotice.get(administeredItemTargetParent.id)) {
+            editController.createEdit(administeredItemTargetParent, EditType.CHANGENOTICE, changeNotice)
+            addedChangeNotice.put(administeredItemTargetParent.id, true)
+        }
+        // Record the change locally and globally
+        String mergeEditDescription = "Item '$creationPatch.path' created in '$targetModel.label\$$targetModel.branchName'"
+        editController.createEdit(administeredItemTargetParent, EditType.MERGE, mergeEditDescription)
+        editController.createEdit(targetModel, EditType.MERGE, mergeEditDescription)
+    }
+
+    void processDeletionPatchIntoModel(FieldPatchDataDTO deletionPatch, M targetModel, M sourceModel, final String changeNotice, final Map<UUID, Boolean> addedChangeNotice) {
+
+        // Find the Item in the target model
+
+        final AdministeredItem administeredItem
+
+        try {
+            administeredItem = pathRepository.findResourcesByPathFromRootResource(targetModel, deletionPatch.path)
+            if (administeredItem == null) {
+                // Doesn't exist. That's ok because we don't want it to exist
+                return
+            }
+        }
+        catch (Exception findingResource) {
+            throw new HttpStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to find path for ${deletionPatch.path.toString()}")
+        }
+
+        String itemRemovedLabel = administeredItem.label ?: "No label"
+        String mergeEditSuffix = itemRemovedLabel ?: administeredItem.domainType ?: ""
+
+        // Delete the item
+        // Use the deletes from controllers where possible
+
+
+        deleteAdministeredItem(administeredItem)
+
+        // Record edits
+
+        AdministeredItem parent = administeredItem.parent
+
+        // Put a change notice once up front for all local changes
+        if (changeNotice && parent != null && !addedChangeNotice.get(parent.id)) {
+            editController.createEdit(parent, EditType.CHANGENOTICE, changeNotice)
+            addedChangeNotice.put(parent.id, true)
+        }
+        // Record the change locally and globally
+        String mergeEditDescription = "Item removed from '$sourceModel.label\$$sourceModel.branchName' - $mergeEditSuffix"
+        if (parent != null) {
+            editController.createEdit(parent, EditType.MERGE, mergeEditDescription)
+        }
+        editController.createEdit(targetModel, EditType.MERGE, mergeEditDescription)
+    }
+
+    void processModificationPatchIntoModel(FieldPatchDataDTO modificationPatch, M targetModel, M sourceModel, final String changeNotice,
+                                           final Map<UUID, Boolean> addedChangeNotice) {
+
+        // Find the Item in the target model
+
+        // This throws an exception if the path is not found
+        // The source path
+        final AdministeredItem administeredItemSource = pathRepository.findResourcesByPathFromRootResource(sourceModel, modificationPatch.path)
+        // The target path
+        final AdministeredItem administeredItemTarget = pathRepository.findResourcesByPathFromRootResource(targetModel, modificationPatch.path)
+
+        final String fieldNameToModify = modificationPatch.fieldName
+
+        if (
+            administeredItemSource[fieldNameToModify] instanceof Number ||
+            administeredItemSource[fieldNameToModify] instanceof String ||
+            administeredItemSource[fieldNameToModify] instanceof Boolean ||
+            administeredItemSource[fieldNameToModify].getClass().isEnum()
+        ) {
+            administeredItemTarget[fieldNameToModify] = administeredItemSource[fieldNameToModify]
+        } else if (administeredItemSource[fieldNameToModify].getClass().getMethod("clone")) {
+            try {
+                Method method = administeredItemSource[fieldNameToModify].getClass().getMethod("clone")
+                administeredItemTarget[fieldNameToModify] = method.invoke(administeredItemSource[fieldNameToModify])
+            } catch (Exception e) {
+                administeredItemTarget[fieldNameToModify] = administeredItemSource[fieldNameToModify]
+            }
+        } else {
+            administeredItemTarget[fieldNameToModify] = administeredItemSource[fieldNameToModify]
+        }
+
+        if (changeNotice && !addedChangeNotice.get(administeredItemTarget.id)) {
+            editController.createEdit(administeredItemTarget, EditType.CHANGENOTICE, changeNotice)
+            addedChangeNotice.put(administeredItemTarget.id, true)
+        }
+        // Record the change locally and globally
+        String mergeEditDescription = "Item modified in '$targetModel.label\$$targetModel.branchName'"
+
+        editController.createEdit(administeredItemTarget, EditType.MERGE, mergeEditDescription)
+        editController.createEdit(targetModel, EditType.MERGE, mergeEditDescription)
+
+        AdministeredItemRepository specificAdministeredItemRepository = pathRepository.getRepository(administeredItemTarget)
+
+        specificAdministeredItemRepository.update(administeredItemTarget)
+    }
+
+    AdministeredItem getWithContents(AdministeredItem item) {
+        AdministeredItemContentRepository specificAdministeredItemContentRepository = getAdministeredItemContentRepository(item)
+        AdministeredItem itemWithContents = specificAdministeredItemContentRepository.readWithContentById(item.id)
+        return itemWithContents
+    }
+
+    void deleteAdministeredItem(AdministeredItem item) throws HttpException {
+        if (item == null) {
+            throw new InternalServerException("Null passed for deletion")
+        }
+
+        try {
+            if (item instanceof Model) {
+                accessControlService.checkRole(Role.CONTAINER_ADMIN, item)
+            } else {
+                deletePre(item)
+                accessControlService.checkRole(Role.EDITOR, item)
+            }
+
+            AdministeredItemContentRepository specificAdministeredItemContentRepository = getAdministeredItemContentRepository(item)
+
+            AdministeredItem itemWithContents = specificAdministeredItemContentRepository.readWithContentById(item.id)
+
+            if (!specificAdministeredItemContentRepository.deleteWithContent(itemWithContents)) {
+                throw new HttpStatusException(HttpStatus.NOT_FOUND, 'Not found for deletion: ' + item.label)
+            }
+        }
+        catch (Throwable th) {
+            if (th instanceof HttpException) {
+                throw (HttpException) th
+            }
+            throw new InternalServerException("Deletion failed", th)
+        }
+    }
+
+    @NonNull
+    AdministeredItemContentRepository getAdministeredItemContentRepository(AdministeredItem item) {
+        administeredItemContentRepositories.find {
+            it.getClass().simpleName != 'AdministeredItemContentRepository' &&
+            it.getClass().simpleName != 'ModelContentRepository' &&
+            it.handles(item.class)
+        } ?:
+        administeredItemContentRepositories.find {
+            it.getClass().simpleName != 'ModelContentRepository' &&
+            it.handles(item.class)
+        } ?:
+        administeredItemContentRepositories.find {
+            it.getClass().simpleName != 'AdministeredItemContentRepository'
+        }
+    }
+
+    private void connectFacets(AdministeredItem administeredItem){
+        if(administeredItem.metadata){
+            administeredItem.metadata.each {
+                updateMultiAwareData(administeredItem, it)
+            }
+        }
+        if (administeredItem.summaryMetadata) {
+            administeredItem.summaryMetadata.each {
+                updateMultiAwareData(administeredItem, it)
+            }
+        }
+        if (administeredItem.rules) {
+            administeredItem.rules.each {
+                updateMultiAwareData(administeredItem, it)
+            }
+        }
+        if (administeredItem.annotations) {
+            administeredItem.annotations.each {
+                updateMultiAwareData(administeredItem, it)
+                if(it.childAnnotations){
+                    it.childAnnotations.forEach {child ->
+                        updateMultiAwareData(administeredItem, child)
+                    }
+                }
+            }
+        }
+        if (administeredItem.referenceFiles) {
+            administeredItem.referenceFiles.each {
+                updateMultiAwareData(administeredItem, it)
+            }
+        }
+        if(administeredItem instanceof Model){
+            if (((Model) administeredItem).versionLinks) {
+                ((Model) administeredItem).versionLinks.each {
+                    updateMultiAwareData(administeredItem, it)
+                }
+            }
+        }
+        if (administeredItem.semanticLinks) {
+            administeredItem.semanticLinks.each {
+                updateMultiAwareData(administeredItem, it)
+            }
+        }
+    }
+
+    private void updateMultiAwareData(AdministeredItem item, Facet it) {
+        it.multiFacetAwareItemDomainType = item.domainType
+        it.multiFacetAwareItemId = item.id
+        it.multiFacetAwareItem = item
+    }
+
 }

--- a/mauro-api/src/main/groovy/org/maurodata/controller/terminology/CodeSetController.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/controller/terminology/CodeSetController.groovy
@@ -2,6 +2,7 @@ package org.maurodata.controller.terminology
 
 import org.maurodata.ErrorHandler
 import org.maurodata.api.Paths
+import org.maurodata.api.model.ModelVersionedRefDTO
 import org.maurodata.api.model.PermissionsDTO
 import org.maurodata.api.terminology.CodeSetApi
 import org.maurodata.audit.Audit
@@ -172,6 +173,13 @@ class CodeSetController extends ModelController<CodeSet> implements CodeSetApi {
 
         codeSet.setAssociations()
         other.setAssociations()
+
+        pathRepository.readParentItems(codeSet)
+        codeSet.updatePath()
+
+        pathRepository.readParentItems(other)
+        other.updatePath()
+
         codeSet.diff(other)
     }
 
@@ -193,9 +201,9 @@ class CodeSetController extends ModelController<CodeSet> implements CodeSetApi {
     }
 
     //stub endpoint todo: actual
-    @Get('/codeSets/{id}/simpleModelVersionTree')
-    List<Map> simpleModelVersionTree(UUID id) {
-        super.simpleModelVersionTree(id)
+    @Get(Paths.CODE_SET_SIMPLE_MODEL_VERSION_TREE)
+    List<ModelVersionedRefDTO> simpleModelVersionTree(UUID id, @Nullable Boolean branchesOnly) {
+        super.simpleModelVersionTree(id,branchesOnly)
     }
 
     @Audit

--- a/mauro-api/src/main/groovy/org/maurodata/controller/terminology/TerminologyController.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/controller/terminology/TerminologyController.groovy
@@ -35,7 +35,6 @@ import org.maurodata.domain.diff.ObjectDiff
 import org.maurodata.domain.model.version.CreateNewVersionData
 import org.maurodata.domain.model.version.FinaliseData
 import org.maurodata.domain.security.Role
-import org.maurodata.domain.terminology.CodeSet
 import org.maurodata.domain.terminology.Terminology
 import org.maurodata.domain.terminology.TerminologyService
 import org.maurodata.persistence.cache.ModelCacheableRepository.FolderCacheableRepository
@@ -201,6 +200,13 @@ class TerminologyController extends ModelController<Terminology> implements Term
 
         terminology.setAssociations()
         other.setAssociations()
+
+        pathRepository.readParentItems(terminology)
+        terminology.updatePath()
+
+        pathRepository.readParentItems(other)
+        other.updatePath()
+
         terminology.diff(other)
     }
 
@@ -277,5 +283,4 @@ class TerminologyController extends ModelController<Terminology> implements Term
 
         return simpleModelVersionTreeList
     }
-
 }

--- a/mauro-api/src/main/groovy/org/maurodata/controller/tree/TreeController.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/controller/tree/TreeController.groovy
@@ -79,7 +79,9 @@ class TreeController implements TreeApi {
     List<TreeItem> itemTree(String domainType, UUID id, @Nullable @QueryValue Boolean foldersOnly) {
         foldersOnly = foldersOnly ?: false
         AdministeredItemCacheableRepository repository = repositoryService.getAdministeredItemRepository(domainType)
-        AdministeredItem item = repository.readById(id)
+        AdministeredItem item = (AdministeredItem) repository.readById(id)
+        pathRepository.readParentItems(item)
+        item.updatePath()
         AvailableActions.updateAvailableActions(item, accessControlService)
 
         accessControlService.checkRole(Role.READER, item)

--- a/mauro-api/src/test/groovy/org/maurodata/datamodel/diff/DataModelFacetDiffsIntegrationSpec.groovy
+++ b/mauro-api/src/test/groovy/org/maurodata/datamodel/diff/DataModelFacetDiffsIntegrationSpec.groovy
@@ -63,8 +63,8 @@ class DataModelFacetDiffsIntegrationSpec extends CommonDataSpec {
         then:
         objectDiff
         objectDiff.label == left.label
-        objectDiff.diffs.size() == 6
-        objectDiff.diffs.each { [AUTHOR, DiffBuilder.DESCRIPTION, DiffBuilder.LABEL, PATH_IDENTIFIER].contains(it.name) }
+        objectDiff.diffs.size() == 5
+        objectDiff.diffs.every { [AUTHOR, DiffBuilder.DESCRIPTION, DiffBuilder.LABEL, DiffBuilder.ANNOTATION, DiffBuilder.METADATA].contains(it.name) }
         ArrayDiff<Collection> annotationsDiff = objectDiff.diffs.find { it -> it.name == DiffBuilder.ANNOTATION } as ArrayDiff<Collection>
         annotationsDiff.name == DiffBuilder.ANNOTATION
         annotationsDiff.deleted.size() == 1
@@ -106,10 +106,10 @@ class DataModelFacetDiffsIntegrationSpec extends CommonDataSpec {
         then:
         objectDiff
         objectDiff.label == left.label
-        objectDiff.diffs.size() == 10
-        objectDiff.diffs.each {
+        objectDiff.diffs.size() == 9
+        objectDiff.diffs.every {
             [AUTHOR, DiffBuilder.DESCRIPTION, DiffBuilder.LABEL,
-             PATH_IDENTIFIER, PATH_MODEL_IDENTIFIER, MODEL_VERSION_TAG, FINALISED, DATE_FINALISED].contains(it.name)
+             PATH_MODEL_IDENTIFIER, MODEL_VERSION_TAG, FINALISED, DATE_FINALISED, DiffBuilder.ANNOTATION, DiffBuilder.METADATA].contains(it.name)
         }
         ArrayDiff<Collection> annotationsDiff = objectDiff.diffs.find { it -> it.name == DiffBuilder.ANNOTATION } as ArrayDiff<Collection>
         annotationsDiff.created.size() == 1
@@ -222,7 +222,7 @@ class DataModelFacetDiffsIntegrationSpec extends CommonDataSpec {
         reportDiffs.deleted[0].get(DiffBuilder.REPORT_VALUE) == leftReport.reportValue
     }
 
-    void 'test datamodel - self does not have summaryMetadata -should show added/deleted '() {
+    void 'test datamodel - self does not have summaryMetadata -should show modified reportValue '() {
         given:
         DataModel right = dataModelApi.create(folderId, dataModelPayload())
 
@@ -244,18 +244,11 @@ class DataModelFacetDiffsIntegrationSpec extends CommonDataSpec {
         ArrayDiff<Collection> summaryMetadataDiff = objectDiff.diffs.find {it.name == DiffBuilder.SUMMARY_METADATA} as ArrayDiff<Collection>
 
         summaryMetadataDiff
-        summaryMetadataDiff.created.size() == 1
-        summaryMetadataDiff.deleted.size() == 1
-        summaryMetadataDiff.modified.isEmpty()
+        summaryMetadataDiff.modified.size() == 1
+        summaryMetadataDiff.created.size() == 0
+        summaryMetadataDiff.deleted.size() == 0
 
-        summaryMetadataDiff.created[0].get(DiffBuilder.SUMMARY_METADATA_REPORT).flatten().find {
-            it.reportDate == rightReport.reportDate
-            it.reportValue == rightReport.reportValue
-        }
-
-        summaryMetadataDiff.deleted[0].get(DiffBuilder.SUMMARY_METADATA_REPORT).flatten().find {
-            it.reportDate == leftReport.reportDate
-            it.reportValue == leftReport.reportValue
-        }
+        summaryMetadataDiff.modified[0].diffs[0].modified[0].diffs[0].left==leftReport.reportValue
+        summaryMetadataDiff.modified[0].diffs[0].modified[0].diffs[0].right==rightReport.reportValue
     }
 }

--- a/mauro-api/src/test/groovy/org/maurodata/datamodel/diff/DataModelSchemaDiffsIntegrationSpec.groovy
+++ b/mauro-api/src/test/groovy/org/maurodata/datamodel/diff/DataModelSchemaDiffsIntegrationSpec.groovy
@@ -35,6 +35,8 @@ class DataModelSchemaDiffsIntegrationSpec extends CommonDataSpec {
     @Shared
     DataModel left
     @Shared
+    DataModel left2
+    @Shared
     DataModel right
 
     void setup() {
@@ -42,6 +44,7 @@ class DataModelSchemaDiffsIntegrationSpec extends CommonDataSpec {
         folderId = response.id
 
         this.left = dataModelApi.create(folderId, dataModelPayload())
+        this.left2 = dataModelApi.create(folderId, dataModelPayload())
 
         this.right = dataModelApi.create(folderId, new DataModel(
             label: 'Test data model',
@@ -71,10 +74,10 @@ class DataModelSchemaDiffsIntegrationSpec extends CommonDataSpec {
 
         then:
         objectDiff
-        objectDiff.numberOfDiffs == 4
-        objectDiff.diffs.size() == 4
-        objectDiff.diffs.each { [AUTHOR, DiffBuilder.DESCRIPTION, DiffBuilder.LABEL, PATH_IDENTIFIER].contains(it.name) }
-        objectDiff.diffs.each { ![DiffBuilder.DATA_CLASSES].contains(it.name) }
+        objectDiff.numberOfDiffs == 3
+        objectDiff.diffs.size() == 3
+        objectDiff.diffs.every { [AUTHOR, DiffBuilder.DESCRIPTION, DiffBuilder.LABEL].contains(it.name) }
+        objectDiff.diffs.every { ![DiffBuilder.DATA_CLASSES].contains(it.name) }
     }
 
     void 'diff dataModels with same modified data class - should show diff with nested child data class '() {
@@ -83,22 +86,22 @@ class DataModelSchemaDiffsIntegrationSpec extends CommonDataSpec {
         DataClass leftDataClass = dataClassApi.create(left.id, dataClassPayload())
 
         DataClass rightDataClass = dataClassApi.create(right.id, new DataClass(
-                label: 'Test data class',
-                description: 'other test description',
-                minMultiplicity: -1))
+            label: 'Test data class',
+            description: 'other test description',
+            minMultiplicity: -1))
 
         //child data class
         DataClass childDataClass = dataClassApi.create(right.id, rightDataClass.id, new DataClass(
-                label: 'Test child',
-                description: 'child test description',
-                minMultiplicity: -2))
+            label: 'Test child',
+            description: 'child test description',
+            minMultiplicity: -2))
 
         when:
         ObjectDiff objectDiff = dataModelApi.diffModels(left.id, right.id)
 
         then:
         objectDiff
-        objectDiff.numberOfDiffs == 7
+        objectDiff.numberOfDiffs == 6
         ArrayDiff<Collection> dataClasses = objectDiff.diffs.find { it -> it.name == DiffBuilder.DATA_CLASSES } as ArrayDiff<Collection>
         dataClasses.created.isEmpty()
         dataClasses.deleted.isEmpty()
@@ -114,11 +117,48 @@ class DataModelSchemaDiffsIntegrationSpec extends CommonDataSpec {
         child.created[0].get(DiffBuilder.LABEL) == childDataClass.label
     }
 
+    void 'diff dataModels with same modified data class 2 - should show diff with nested child data class '() {
+        given:
+        //modified comparison key = label
+        DataClass leftDataClass = dataClassApi.create(left.id, dataClassPayload())
+
+        DataClass rightDataClass = dataClassApi.create(left2.id, new DataClass(
+                label: 'Test data class',
+                description: 'other test description',
+                minMultiplicity: -1))
+
+        //child data class
+        DataClass childDataClass = dataClassApi.create(left2.id, rightDataClass.id, new DataClass(
+                label: 'Test child',
+                description: 'child test description',
+                minMultiplicity: -2))
+
+        when:
+        ObjectDiff objectDiff = dataModelApi.diffModels(left.id, left2.id)
+
+        then:
+        objectDiff
+        objectDiff.numberOfDiffs == 3
+        ArrayDiff<Collection> dataClasses = objectDiff.diffs.find { it -> it.name == DiffBuilder.DATA_CLASSES } as ArrayDiff<Collection>
+        dataClasses.created.isEmpty()
+        dataClasses.deleted.isEmpty()
+        dataClasses.modified.size() == 1
+        dataClasses.modified[0].numberOfDiffs == 3
+        dataClasses.modified[0].diffs.every { [DiffBuilder.DESCRIPTION, DiffBuilder.MIN_MULTIPILICITY, DiffBuilder.DATA_CLASSES].contains(it.name) }
+        ArrayDiff<Collection> child = dataClasses.modified[0].diffs.find { it.name == DiffBuilder.DATA_CLASSES }
+        child
+        child.deleted.isEmpty()
+        child.modified.isEmpty()
+        child.created.size() == 1
+        child.created[0].get(DiffBuilder.ID_KEY) == childDataClass.id.toString()
+        child.created[0].get(DiffBuilder.LABEL) == childDataClass.label
+    }
+
 
     void 'diff dataModels with same modified data class with left and right sides reversed - count should be same as previous test '() {
         given:
         //modified comparison key = label
-        DataClass rightDataClass = dataClassApi.create(right.id, dataClassPayload())
+        DataClass rightDataClass = dataClassApi.create(left2.id, dataClassPayload())
 
         DataClass leftDataClass = dataClassApi.create(left.id, new DataClass(
             label: 'Test data class',
@@ -132,17 +172,17 @@ class DataModelSchemaDiffsIntegrationSpec extends CommonDataSpec {
             minMultiplicity: -2))
 
         when:
-        ObjectDiff objectDiff = dataModelApi.diffModels(left.id, right.id)
+        ObjectDiff objectDiff = dataModelApi.diffModels(left.id, left2.id)
 
         then:
         objectDiff
-        objectDiff.numberOfDiffs == 7
+        objectDiff.numberOfDiffs == 3
         ArrayDiff<Collection> dataClasses = objectDiff.diffs.find { it -> it.name == DiffBuilder.DATA_CLASSES } as ArrayDiff<Collection>
         dataClasses.created.isEmpty()
         dataClasses.deleted.isEmpty()
         dataClasses.modified.size() == 1
         dataClasses.modified[0].numberOfDiffs == 3
-        dataClasses.modified[0].diffs.each { [DiffBuilder.DESCRIPTION, DiffBuilder.MIN_MULTIPILICITY, DiffBuilder.DATA_CLASSES].contains(it.name) }
+        dataClasses.modified[0].diffs.every { [DiffBuilder.DESCRIPTION, DiffBuilder.MIN_MULTIPILICITY, DiffBuilder.DATA_CLASSES].contains(it.name) }
         ArrayDiff<Collection> child = dataClasses.modified[0].diffs.find { it.name == DiffBuilder.DATA_CLASSES }
         child
         child.created.isEmpty()
@@ -151,7 +191,6 @@ class DataModelSchemaDiffsIntegrationSpec extends CommonDataSpec {
         child.deleted[0].get(DiffBuilder.ID_KEY) == childDataClass.id.toString()
         child.deleted[0].get(DiffBuilder.LABEL) == childDataClass.label
     }
-
 
     void 'diff dataModels with dataType diffs'() {
         given:
@@ -164,7 +203,7 @@ class DataModelSchemaDiffsIntegrationSpec extends CommonDataSpec {
 
         then:
         objectDiff
-        objectDiff.numberOfDiffs == 5
+        objectDiff.numberOfDiffs == 4
         ArrayDiff<Collection> dataTypesDiff = objectDiff.diffs.find { it.name == DiffBuilder.DATA_TYPE }
         dataTypesDiff.created.isEmpty()
         dataTypesDiff.modified.isEmpty()
@@ -175,6 +214,27 @@ class DataModelSchemaDiffsIntegrationSpec extends CommonDataSpec {
         dataTypesDiff.deleted[0].get(DiffBuilder.LABEL) == leftDataType.label
     }
 
+    void 'diff dataModels with dataType diffs 2'() {
+        given:
+        //modified comparison key = label
+        DataType leftDataType =
+            dataTypeApi.create(left.id, dataTypesPayload())
+
+        when:
+        ObjectDiff objectDiff = dataModelApi.diffModels(left.id, left2.id)
+
+        then:
+        objectDiff
+        objectDiff.numberOfDiffs == 1
+        ArrayDiff<Collection> dataTypesDiff = objectDiff.diffs.find { it.name == DiffBuilder.DATA_TYPE }
+        dataTypesDiff.created.isEmpty()
+        dataTypesDiff.modified.isEmpty()
+        dataTypesDiff.deleted.size() == 1
+
+        dataTypesDiff.deleted.size() == 1
+        dataTypesDiff.deleted[0].get(DiffBuilder.ID_KEY) == leftDataType.id.toString()
+        dataTypesDiff.deleted[0].get(DiffBuilder.LABEL) == leftDataType.label
+    }
 
     void 'diff dataModels with DataClasses and DataElements -the dataClass should show nested dataElement'() {
         given:
@@ -215,6 +275,45 @@ class DataModelSchemaDiffsIntegrationSpec extends CommonDataSpec {
         dataElement[0].get(DiffBuilder.ID_KEY) == leftDataElement.id.toString()
     }
 
+    void 'diff dataModels with DataClasses and DataElements -the dataClass should show nested dataElement 2'() {
+        given:
+        //modified comparison key = label
+        DataClass leftDataClass =
+            dataClassApi.create(left.id, dataClassPayload())
+        DataClass rightDataClass =
+            dataClassApi.create(left2.id, dataClassPayload())
+
+        DataType leftDataTypeResponse =
+            dataTypeApi.create(left.id, dataTypesPayload())
+
+        DataElement leftDataElement = dataElementApi.create(left.id, leftDataClass.id, new DataElement(
+            label: 'data element',
+            description: 'The first data element description',
+            dataType: leftDataTypeResponse))
+
+        when:
+        ObjectDiff objectDiff = dataModelApi.diffModels(left.id, left2.id)
+
+        then:
+        objectDiff
+        objectDiff.diffs.every { [DiffBuilder.DATA_CLASSES, DiffBuilder.DATA_ELEMENTS, DiffBuilder.DATA_TYPE].contains(it.name) }
+        ArrayDiff<Collection> dataClassesDiff = objectDiff.diffs.find { it.name == DiffBuilder.DATA_CLASSES }
+        dataClassesDiff.created.isEmpty()
+        dataClassesDiff.deleted.isEmpty()
+        dataClassesDiff.modified.size() == 1
+        dataClassesDiff.modified.diffs.size() == 1
+        dataClassesDiff.modified.diffs.each {
+            [NAME, DELETED].contains(it.name)
+        }
+
+        Collection<FieldDiff> nestedDataElement = dataClassesDiff.modified.diffs[0]
+        nestedDataElement.size() == 1
+        ArrayDiff dataElementMap = nestedDataElement[0]
+        Collection<FieldDiff> dataElement = dataElementMap.deleted
+        dataElement[0].get(DiffBuilder.LABEL) == leftDataElement.label
+        dataElement[0].get(DiffBuilder.ID_KEY) == leftDataElement.id.toString()
+    }
+
     void 'diff dataModels with DataClasses and nested DataElements on RHS  -should give same counts as when on LHS'() {
         given:
         //modified comparison key = label
@@ -226,9 +325,9 @@ class DataModelSchemaDiffsIntegrationSpec extends CommonDataSpec {
 
 
         DataElement rightDataElement = dataElementApi.create(right.id, rightDataClass.id,
-                new DataElement(label: 'data element',
-                                description: 'The first data element description',
-                                dataType: rightDataTypeResponse))
+                                                             new DataElement(label: 'data element',
+                                                                             description: 'The first data element description',
+                                                                             dataType: rightDataTypeResponse))
 
         //validation of dataElement on dataClass
         and:
@@ -247,6 +346,51 @@ class DataModelSchemaDiffsIntegrationSpec extends CommonDataSpec {
         then:
         objectDiff
         objectDiff.diffs.each { [AUTHOR, DiffBuilder.DESCRIPTION, DiffBuilder.DATA_CLASSES].contains(it.name) }
+        ArrayDiff<Collection> dataClassesDiff = objectDiff.diffs.find { it.name == DiffBuilder.DATA_CLASSES } as ArrayDiff<Collection>
+        dataClassesDiff.deleted.isEmpty()
+        dataClassesDiff.created.isEmpty()
+        dataClassesDiff.modified.size() == 1
+
+        List<FieldDiff> nestedDataElement = dataClassesDiff.modified.diffs[0]
+        nestedDataElement.size() == 1
+        ArrayDiff dataElementMap = nestedDataElement[0]
+        List<DataElement> dataElement = dataElementMap.created
+        dataElement[0].label == rightDataElement.label
+        dataElement[0].id == rightDataElement.id.toString()
+    }
+
+    void 'diff dataModels with DataClasses and nested DataElements on RHS  -should give same counts as when on LHS 2'() {
+        given:
+        //modified comparison key = label
+        DataClass leftDataClass = dataClassApi.create(left.id, dataClassPayload())
+        DataClass rightDataClass = dataClassApi.create(left2.id, dataClassPayload())
+
+        DataType leftDataTypeResponse = dataTypeApi.create(left.id, dataTypesPayload())
+        DataType rightDataTypeResponse = dataTypeApi.create(left2.id, dataTypesPayload())
+
+
+        DataElement rightDataElement = dataElementApi.create(left2.id, rightDataClass.id,
+                new DataElement(label: 'data element',
+                                description: 'The first data element description',
+                                dataType: rightDataTypeResponse))
+
+        //validation of dataElement on dataClass
+        and:
+        ListResponse<DataElement> dataElementListResponse =
+            dataElementApi.list(left2.id, rightDataClass.id)
+        dataElementListResponse.count == 1
+
+        when:
+        DataElement retrievedDataElement = dataElementListResponse.getItems().first()
+        then:
+        retrievedDataElement.dataType.id.toString() == rightDataTypeResponse.id.toString()
+
+        when:
+        ObjectDiff objectDiff = dataModelApi.diffModels(left.id, left2.id)
+
+        then:
+        objectDiff
+        objectDiff.diffs.every { [DiffBuilder.DATA_CLASSES, DiffBuilder.DATA_ELEMENTS, DiffBuilder.DATA_TYPE].contains(it.name) }
         ArrayDiff<Collection> dataClassesDiff = objectDiff.diffs.find { it.name == DiffBuilder.DATA_CLASSES } as ArrayDiff<Collection>
         dataClassesDiff.deleted.isEmpty()
         dataClassesDiff.created.isEmpty()

--- a/mauro-api/src/test/groovy/org/maurodata/datamodel/diff/DataModelSchemaMergeDiffsIntegrationSpec.groovy
+++ b/mauro-api/src/test/groovy/org/maurodata/datamodel/diff/DataModelSchemaMergeDiffsIntegrationSpec.groovy
@@ -1,0 +1,384 @@
+package org.maurodata.datamodel.diff
+
+import org.maurodata.api.model.FieldPatchDataDTO
+import org.maurodata.api.model.MergeDiffDTO
+import org.maurodata.api.model.MergeIntoDTO
+import org.maurodata.api.model.ObjectPatchDataDTO
+import org.maurodata.domain.datamodel.DataClass
+import org.maurodata.domain.datamodel.DataElement
+import org.maurodata.domain.datamodel.DataModel
+import org.maurodata.domain.datamodel.DataType
+import org.maurodata.domain.diff.ArrayDiff
+import org.maurodata.domain.diff.DiffBuilder
+import org.maurodata.domain.diff.FieldDiff
+import org.maurodata.domain.diff.ObjectDiff
+import org.maurodata.domain.folder.Folder
+import org.maurodata.domain.model.Path
+import org.maurodata.domain.model.version.CreateNewVersionData
+import org.maurodata.domain.model.version.FinaliseData
+import org.maurodata.domain.model.version.VersionChangeType
+import org.maurodata.persistence.ContainerizedTest
+import org.maurodata.testing.CommonDataSpec
+import org.maurodata.web.ListResponse
+
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.test.annotation.Sql
+import jakarta.inject.Singleton
+import spock.lang.Shared
+
+@ContainerizedTest
+@Singleton
+@Sql(scripts = "classpath:sql/tear-down-datamodel.sql", phase = Sql.Phase.AFTER_EACH)
+class DataModelSchemaMergeDiffsIntegrationSpec extends CommonDataSpec {
+    static String NAME = 'name'
+    static String CREATED = 'created'
+    static String DELETED = 'deleted'
+
+    @Shared
+    UUID folderId
+
+    @Shared
+    DataModel one
+    @Shared
+    DataModel two
+    @Shared
+    DataModel ancestor
+    @Shared
+    DataModel ancestorAlternative
+    @Shared
+    DataModel branch
+    @Shared
+    DataModel main
+    @Shared
+    DataModel mainAlternative
+    @Shared
+    DataClass ancestorDataClass
+
+    void setup() {
+        Folder response = folderApi.create(folder())
+        folderId = response.id
+
+        this.one = dataModelApi.create(folderId, dataModelPayload())
+        this.two = dataModelApi.create(folderId, dataModelPayload())
+
+        UUID ancestorId = dataModelApi.create(folderId, dataModelPayload()).id
+
+        this.ancestorDataClass = dataClassApi.create(ancestorId, new DataClass(
+            label: 'A data class',
+            description: 'description',
+            minMultiplicity: -1))
+
+        this.ancestor = dataModelApi.finalise(
+            ancestorId,
+            new FinaliseData(versionChangeType: VersionChangeType.MAJOR, versionTag: 'ancestor'))
+
+        UUID ancestorAlternativeId = dataModelApi.create(folderId, dataModelPayload()).id
+
+        this.ancestorAlternative = dataModelApi.finalise(
+            ancestorAlternativeId,
+            new FinaliseData(versionChangeType: VersionChangeType.MAJOR, versionTag: 'ancestor'))
+
+        this.branch =
+            dataModelApi.createNewBranchModelVersion(
+                ancestorId,
+                new CreateNewVersionData(branchName: 'branch' ))
+
+        this.main =
+            dataModelApi.createNewBranchModelVersion(
+                ancestorId,
+                new CreateNewVersionData(label: '1.0.1', branchName: 'main' ))
+
+        this.mainAlternative =
+            dataModelApi.createNewBranchModelVersion(
+                ancestorAlternativeId,
+                new CreateNewVersionData(label: '1.0.2', branchName: 'main' ))
+
+    }
+
+    MergeIntoDTO mergeIntoDTOFromMergeDiffDTO(MergeDiffDTO mergeDiffDTO){
+
+        ObjectPatchDataDTO patch = new ObjectPatchDataDTO(sourceId: mergeDiffDTO.sourceId, targetId: mergeDiffDTO.targetId, label: mergeDiffDTO.label)
+        mergeDiffDTO.diffs.forEach {
+            FieldPatchDataDTO fieldPatchDataDTO=new FieldPatchDataDTO(
+                fieldName: it.fieldName,
+                path: new Path(it.path),
+                sourceValue: it.sourceValue,
+                targetValue: it.targetValue,
+                isMergeConflict: it.isMergeConflict,
+                _type: it._type
+                )
+            patch.patches.add(fieldPatchDataDTO)
+        }
+
+        MergeIntoDTO mergeIntoDTO=new MergeIntoDTO(patch: patch)
+
+        return mergeIntoDTO
+    }
+
+    void 'mergediff without finalised ancestor - 1st param should throw error'() {
+        when:
+        MergeDiffDTO mergeDiff = dataModelApi.mergeDiff(one.id, two.id)
+        then:
+        HttpClientResponseException exception = thrown()
+        exception.status == HttpStatus.UNPROCESSABLE_ENTITY
+        String jsonString = exception.response.getBody(String).orElse(null)
+        System.out.println(jsonString)
+        jsonString.contains("MS01")
+    }
+
+    void 'mergediff without finalised ancestor - 2nd param should throw error'() {
+        when:
+        MergeDiffDTO mergeDiff = dataModelApi.mergeDiff(main.id, two.id)
+        then:
+        HttpClientResponseException exception = thrown()
+        exception.status == HttpStatus.UNPROCESSABLE_ENTITY
+        String jsonString = exception.response.getBody(String).orElse(null)
+        System.out.println(jsonString)
+        jsonString.contains("MS02")
+    }
+
+    void 'mergediff with finalised target - should throw error'() {
+        when:
+        MergeDiffDTO mergeDiff = dataModelApi.mergeDiff(ancestor.id, ancestorAlternative.id)
+        then:
+        HttpClientResponseException exception = thrown()
+        exception.status == HttpStatus.UNPROCESSABLE_ENTITY
+        String jsonString = exception.response.getBody(String).orElse(null)
+        System.out.println(jsonString)
+        jsonString.contains("MS03")
+    }
+
+    void 'mergediff with unrelated ancestors - should throw error'() {
+        when:
+        MergeDiffDTO mergeDiff = dataModelApi.mergeDiff(main.id, mainAlternative.id)
+        then:
+        HttpClientResponseException exception = thrown()
+        exception.status == HttpStatus.UNPROCESSABLE_ENTITY
+        String jsonString = exception.response.getBody(String).orElse(null)
+        System.out.println(jsonString)
+        jsonString.contains("MS04")
+    }
+
+    void 'mergediff on same datamodel - should show no merge diffs'() {
+        when:
+        MergeDiffDTO mergeDiff = dataModelApi.mergeDiff(main.id, main.id)
+        then:
+        mergeDiff.count == 0
+    }
+
+    void 'mergediff on newly branched datamodels - should show no merge diffs'() {
+        when:
+        MergeDiffDTO mergeDiff = dataModelApi.mergeDiff(main.id, branch.id)
+        then:
+        mergeDiff.count == 0
+    }
+
+    void 'mergediff update branch datamodel label - should label update diff'() {
+        when:
+        DataModel updated=dataModelApi.update(branch.id, new DataModel(label:"Changed label"))
+        MergeDiffDTO mergeDiff = dataModelApi.mergeDiff(branch.id, main.id)
+        then:
+        mergeDiff.diffs.every {
+            it.fieldName == 'label' && it.sourceValue == 'Changed label' && !it.isMergeConflict
+        }
+    }
+
+    void 'mergediff add data class - should add a data class diff'() {
+        when:
+
+        dataClassApi.create(branch.id, dataClassPayload())
+        MergeDiffDTO mergeDiff = dataModelApi.mergeDiff(branch.id, main.id)
+        then:
+        mergeDiff.diffs.every {
+            it.fieldName == 'dataClasses' && it.path == 'dm:test label $main|dc:Test data class' && it._type == 'creation'
+        }
+    }
+
+    void 'mergediff add data class and child class - should add a data class diff'() {
+        when:
+
+        DataClass dataClass = dataClassApi.create(branch.id, new DataClass(
+            label: 'Test data class',
+            description: 'other test description',
+            minMultiplicity: -1))
+
+        DataClass childDataClass = dataClassApi.create(branch.id, dataClass.id, new DataClass(
+            label: 'Test child',
+            description: 'child test description',
+            minMultiplicity: -2))
+
+        MergeDiffDTO mergeDiff = dataModelApi.mergeDiff(branch.id, main.id)
+        then:
+        // Note: even though there are two dataclasses added, this is only one merge difference
+        mergeDiff.diffs.every {
+            it.fieldName == 'dataClasses' && it.path == 'dm:test label $main|dc:Test data class' && it._type == 'creation'
+        }
+    }
+
+    void 'mergediff modify data class - should present modify diff'() {
+        when:
+
+        ListResponse<DataClass> dataClassListResponse = dataClassApi.allDataClasses(branch.id)
+        DataClass dataClass = dataClassListResponse.items.get(0)
+        dataClassApi.update(branch.id, dataClass.id, new DataClass(description:"A different description"))
+        MergeDiffDTO mergeDiff = dataModelApi.mergeDiff(branch.id, main.id)
+
+        then:
+        mergeDiff.diffs.every {
+            it.fieldName == 'description' && it._type == 'modification'
+        }
+    }
+
+    void 'mergediff delete data class - should delete diff'() {
+        when:
+
+        ListResponse<DataClass> dataClassListResponse = dataClassApi.allDataClasses(branch.id)
+        DataClass dataClass = dataClassListResponse.items.get(0)
+
+        dataClassApi.delete(branch.id, dataClass.id, dataClass)
+        MergeDiffDTO mergeDiff = dataModelApi.mergeDiff(branch.id, main.id)
+
+        then:
+        mergeDiff.diffs.every {
+            it.fieldName == 'dataClasses' && it.isMergeConflict && it._type == 'deletion'
+        }
+    }
+
+    void 'mergediff delete data class - should not add diff'() {
+        when:
+
+        ListResponse<DataClass> dataClassListResponse = dataClassApi.allDataClasses(branch.id)
+        DataClass dataClass = dataClassListResponse.items.get(0)
+
+        dataClassApi.delete(branch.id, dataClass.id, dataClass)
+
+        // Swap branch and main, ie merging into branch from main
+        MergeDiffDTO mergeDiff = dataModelApi.mergeDiff(main.id, branch.id)
+
+        then:
+        mergeDiff.count == 0
+    }
+
+    void 'mergediff add data class in one branch and delete in another - should merge conflict diff'() {
+        when:
+
+        // Add child dataclass to dataclass in main
+        ListResponse<DataClass> dataClassListResponse_main = dataClassApi.allDataClasses(main.id)
+        DataClass dataClass_main = dataClassListResponse_main.items.get(0)
+
+        DataClass childDataClass = dataClassApi.create(main.id, dataClass_main.id, new DataClass(
+            label: 'Test child',
+            description: 'child test description',
+            minMultiplicity: -2))
+
+        // Delete that dataclass in branch
+        ListResponse<DataClass> dataClassListResponse = dataClassApi.allDataClasses(branch.id)
+        DataClass dataClass = dataClassListResponse.items.get(0)
+
+        dataClassApi.delete(branch.id, dataClass.id, dataClass)
+        MergeDiffDTO mergeDiff = dataModelApi.mergeDiff(branch.id, main.id)
+
+        then:
+        mergeDiff.diffs.any {
+            it.fieldName == 'dataClasses' && it.isMergeConflict && it._type == 'deletion' && it.path=='dm:test label $main|dc:A data class'
+        }
+        mergeDiff.diffs.any {
+            it.fieldName == 'dataClasses' && it.isMergeConflict && it._type == 'deletion' && it.path=='dm:test label $main|dc:A data class|dc:Test child'
+        }
+    }
+
+    void 'mergeinto update branch label'() {
+        when:
+        DataModel updated=dataModelApi.update(branch.id, new DataModel(label:"Changed label"))
+        MergeDiffDTO mergeDiff = dataModelApi.mergeDiff(branch.id, main.id)
+
+        MergeIntoDTO mergeIntoDTO=mergeIntoDTOFromMergeDiffDTO(mergeDiff)
+
+        DataModel resultOfMerge = dataModelApi.mergeInto(mergeIntoDTO.patch.sourceId, mergeIntoDTO.patch.targetId, mergeIntoDTO)
+
+        ObjectDiff objectDiff = dataModelApi.diffModels(branch.id, main.id)
+        then:
+        resultOfMerge.label == 'Changed label'
+        objectDiff.diffs.every {
+            it.name == 'branchName' || it.name == 'pathModelIdentifier'
+        }
+    }
+
+    void 'mergeinto add data class in one branch and delete in another'() {
+        when:
+
+        // Add child dataclass to dataclass in main
+        ListResponse<DataClass> dataClassListResponse_main = dataClassApi.allDataClasses(main.id)
+        DataClass dataClass_main = dataClassListResponse_main.items.get(0)
+
+        DataClass childDataClass = dataClassApi.create(main.id, dataClass_main.id, new DataClass(
+            label: 'Test child',
+            description: 'child test description',
+            minMultiplicity: -2))
+
+        // Delete that dataclass in branch
+        ListResponse<DataClass> dataClassListResponse = dataClassApi.allDataClasses(branch.id)
+        DataClass dataClass = dataClassListResponse.items.get(0)
+
+        dataClassApi.delete(branch.id, dataClass.id, dataClass)
+        MergeDiffDTO mergeDiff = dataModelApi.mergeDiff(branch.id, main.id)
+
+        MergeIntoDTO mergeIntoDTO=mergeIntoDTOFromMergeDiffDTO(mergeDiff)
+
+        DataModel resultOfMerge = dataModelApi.mergeInto(mergeIntoDTO.patch.sourceId, mergeIntoDTO.patch.targetId, mergeIntoDTO)
+
+        ObjectDiff objectDiff = dataModelApi.diffModels(branch.id, main.id)
+
+        then:
+        objectDiff.diffs.every {
+            it.name == 'branchName' || it.name == 'pathModelIdentifier'
+        }
+    }
+
+    void 'merginto add data class and child class'() {
+        when:
+
+        DataClass dataClass = dataClassApi.create(branch.id, new DataClass(
+            label: 'Test data class',
+            description: 'other test description',
+            minMultiplicity: -1))
+
+        DataClass childDataClass = dataClassApi.create(branch.id, dataClass.id, new DataClass(
+            label: 'Test child',
+            description: 'child test description',
+            minMultiplicity: -2))
+
+        MergeDiffDTO mergeDiff = dataModelApi.mergeDiff(branch.id, main.id)
+
+        MergeIntoDTO mergeIntoDTO=mergeIntoDTOFromMergeDiffDTO(mergeDiff)
+
+        DataModel resultOfMerge = dataModelApi.mergeInto(mergeIntoDTO.patch.sourceId, mergeIntoDTO.patch.targetId, mergeIntoDTO)
+
+
+
+        ObjectDiff objectDiff = dataModelApi.diffModels(branch.id, main.id)
+
+        then:
+        objectDiff.diffs.every {
+            it.name == 'branchName' || it.name == 'pathModelIdentifier'
+        }
+    }
+
+    /*
+    mergeDiff.diffs.forEach {
+            System.out.println(it.dump())
+        }
+        mergeDiff.diffs.every {
+            it.fieldName == 'dataClasses' && it.isMergeConflict && it._type == 'deletion'
+        }
+        mergeDiff.diffs.any {
+            it.fieldName == 'dataClasses' && it.isMergeConflict && it._type == 'deletion'
+        }
+     */
+
+}
+
+
+

--- a/mauro-api/src/test/groovy/org/maurodata/facet/SemanticLinkIntegrationSpec.groovy
+++ b/mauro-api/src/test/groovy/org/maurodata/facet/SemanticLinkIntegrationSpec.groovy
@@ -63,15 +63,11 @@ class SemanticLinkIntegrationSpec extends CommonDataSpec {
         createdSemanticLink.targetMultiFacetAwareItem.id == dataClassId_2
         createdSemanticLink.targetMultiFacetAwareItem.label == "Data class 2"
         createdSemanticLink.targetMultiFacetAwareItem.domainType == "DataClass"
-        System.out.println(createdSemanticLink.dump())
-        System.out.println(createdSemanticLink.sourceMultiFacetAwareItem.dump())
-        System.out.println(createdSemanticLink.targetMultiFacetAwareItem.dump())
 
         when:
         ListResponse<SemanticLinkDTO> semanticLinks = semanticLinksApi.list("dataClasses", dataClassId_1)
 
         then:
         semanticLinks.count == 1
-        System.out.println(semanticLinks.dump())
     }
 }

--- a/mauro-client/src/main/groovy/org/maurodata/api/Paths.groovy
+++ b/mauro-client/src/main/groovy/org/maurodata/api/Paths.groovy
@@ -137,7 +137,7 @@ interface Paths {
     String DATA_MODEL_READ_BY_AUTHENTICATED = '/dataModels/{id}/readByAuthenticated'
     String DATA_MODEL_READ_BY_EVERYONE = '/dataModels/{id}/readByEveryone'
     String DATA_MODEL_VERSION_LINKS = '/dataModels/{id}/versionLinks'
-    String DATA_MODEL_SIMPLE_MODEL_VERSION_TREE = '/dataModels/{id}/simpleModelVersionTree'
+    String DATA_MODEL_SIMPLE_MODEL_VERSION_TREE = '/dataModels/{id}/simpleModelVersionTree{?branchesOnly}'
     String DATA_MODEL_MODEL_VERSION_TREE = '/dataModels/{id}/modelVersionTree'
     String DATA_MODEL_CURRENT_MAIN_BRANCH = '/dataModels/{id}/currentMainBranch'
     String DATA_MODEL_LATEST_MODEL_VERSION = '/dataModels/{id}/latestModelVersion'
@@ -148,6 +148,7 @@ interface Paths {
     String DATA_MODEL_DOI = '/dataModels/{id}/doi'
     String DATA_MODEL_DATATYPE_PROVIDERS = '/dataModels/providers/defaultDataTypeProviders'
     String DATA_MODEL_TYPES = '/dataModels/types'
+    String DATA_MODEL_MERGE_INTO = '/dataModels/{id}/mergeInto/{otherId}'
 
 
     /*
@@ -265,13 +266,15 @@ interface Paths {
     String VERSIONED_FOLDER_PERMISSIONS = '/versionedFolders/{id}/permissions'
     String VERSIONED_FOLDER_DOI = '/versionedFolders/{id}/doi'
 
-    String VERSIONED_FOLDER_SIMPLE_MODEL_VERSION_TREE = '/versionedFolders/{id}/simpleModelVersionTree'
+    String VERSIONED_FOLDER_SIMPLE_MODEL_VERSION_TREE = '/versionedFolders/{id}/simpleModelVersionTree{?branchesOnly}'
     String VERSIONED_FOLDER_MODEL_VERSION_TREE = '/versionedFolders/{id}/modelVersionTree'
     String VERSIONED_FOLDER_CURRENT_MAIN_BRANCH = '/versionedFolders/{id}/currentMainBranch'
     String VERSIONED_FOLDER_LATEST_MODEL_VERSION = '/versionedFolders/{id}/latestModelVersion'
     String VERSIONED_FOLDER_LATEST_FINALISED_MODEL = '/versionedFolders/{id}/latestFinalisedModel'
     String VERSIONED_FOLDER_COMMON_ANCESTOR = '/versionedFolders/{id}/commonAncestor/{other_model_id}'
     String VERSIONED_FOLDER_MERGE_DIFF = '/versionedFolders/{id}/mergeDiff/{otherId}'
+    String VERSIONED_FOLDER_MERGE_INTO = '/versionedFolders/{id}/mergeInto/{otherId}'
+
 
     /*
     * ImporterApi
@@ -344,6 +347,7 @@ interface Paths {
     String CODE_SET_DOI = '/codeSets/{id}/doi'
     String CODE_SET_LIST_PAGED = '/codeSets{?params*}'
     String CODE_SET_TERM_LIST_PAGED = '/codeSets/{id}/terms{?params*}'
+    String CODE_SET_SIMPLE_MODEL_VERSION_TREE='/codeSets/{id}/simpleModelVersionTree{?branchesOnly}'
 
     /*
     * TerminologyApi
@@ -365,7 +369,7 @@ interface Paths {
     String TERMINOLOGY_LIST_EXPORTERS = '/terminologies/providers/exporters'
     String TERMINOLOGY_DOI = '/terminologies/{id}/doi'
 
-    String TERMINOLOGY_SIMPLE_MODEL_VERSION_TREE = '/terminologies/{id}/simpleModelVersionTree'
+    String TERMINOLOGY_SIMPLE_MODEL_VERSION_TREE = '/terminologies/{id}/simpleModelVersionTree{?branchesOnly}'
     String TERMINOLOGY_LIST_PAGED = '/terminologies{?params*}'
 
 

--- a/mauro-client/src/main/groovy/org/maurodata/api/datamodel/DataModelApi.groovy
+++ b/mauro-client/src/main/groovy/org/maurodata/api/datamodel/DataModelApi.groovy
@@ -1,5 +1,7 @@
 package org.maurodata.api.datamodel
 
+import org.maurodata.api.model.MergeIntoDTO
+
 import io.micronaut.http.annotation.QueryValue
 import org.maurodata.api.MauroApi
 import org.maurodata.api.Paths
@@ -18,7 +20,6 @@ import org.maurodata.domain.model.version.CreateNewVersionData
 import org.maurodata.domain.model.version.FinaliseData
 import org.maurodata.domain.search.dto.SearchRequestDTO
 import org.maurodata.domain.search.dto.SearchResultsDTO
-import org.maurodata.domain.terminology.CodeSet
 import org.maurodata.plugin.datatype.DefaultDataTypeProviderPlugin
 import org.maurodata.plugin.importer.DataModelImporterPlugin
 import org.maurodata.web.ListResponse
@@ -120,6 +121,9 @@ interface DataModelApi extends ModelApi<DataModel> {
 
     @Get(Paths.DATA_MODEL_MERGE_DIFF)
     MergeDiffDTO mergeDiff(@NonNull UUID id, @NonNull UUID otherId)
+
+    @Put(Paths.DATA_MODEL_MERGE_INTO)
+    DataModel mergeInto(@NonNull UUID id, @NonNull UUID otherId, @Body @Nullable MergeIntoDTO mergeIntoDTO)
 
     @Get(Paths.DATA_MODEL_DOI)
     Map doi(UUID id)

--- a/mauro-client/src/main/groovy/org/maurodata/api/folder/VersionedFolderApi.groovy
+++ b/mauro-client/src/main/groovy/org/maurodata/api/folder/VersionedFolderApi.groovy
@@ -1,5 +1,7 @@
 package org.maurodata.api.folder
 
+import org.maurodata.api.model.MergeIntoDTO
+
 import io.micronaut.core.annotation.NonNull
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.http.HttpResponse
@@ -79,6 +81,8 @@ interface VersionedFolderApi extends ModelApi<Folder> {
     @Get(Paths.VERSIONED_FOLDER_MERGE_DIFF)
     MergeDiffDTO mergeDiff(@NonNull UUID id, @NonNull UUID otherId)
 
+    @Put(Paths.VERSIONED_FOLDER_MERGE_INTO)
+    Folder mergeInto(@NonNull UUID id, @NonNull UUID otherId, @Body @Nullable MergeIntoDTO mergeIntoDTO)
 
     @Put(Paths.VERSIONED_FOLDER_READ_BY_EVERYONE)
     Folder allowReadByEveryone(UUID id)

--- a/mauro-client/src/main/groovy/org/maurodata/api/model/FieldPatchDataDTO.groovy
+++ b/mauro-client/src/main/groovy/org/maurodata/api/model/FieldPatchDataDTO.groovy
@@ -1,0 +1,60 @@
+package org.maurodata.api.model
+
+import org.maurodata.domain.model.Path
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
+
+class FieldPatchDataDTO implements Comparable<FieldPatchDataDTO>{
+
+    String fieldName
+    Path path
+    Object sourceValue
+    Object targetValue
+    Object commonAncestorValue
+    boolean isMergeConflict
+    @JsonProperty('type')
+    String _type
+
+    @Override
+    int compareTo(FieldPatchDataDTO that) {
+        switch (this._type) {
+            case 'modification':
+                if (that._type == 'modification') return 0
+                else return 1
+            case 'creation':
+                if (that._type == 'modification') return -1
+                if (that._type == 'deletion') return -1
+                return 0
+            case 'deletion':
+                if (that._type == 'modification') return -1
+                if (that._type == 'creation') return 1
+                return 0
+        }
+    }
+
+    @Override
+    boolean equals(o) {
+        if (this.is(o)) return true
+        if (getClass() != o.class) return false
+
+        FieldPatchDataDTO that = (FieldPatchDataDTO) o
+
+        if (isMergeConflict != that.isMergeConflict) return false
+        if (fieldName != that.fieldName) return false
+        if (path != that.path) return false
+        if (_type != that._type) return false
+
+        return true
+    }
+
+    @JsonIgnore
+    FieldPatchDataDTO getParentPathPatch() {
+        final FieldPatchDataDTO parentPatch = new FieldPatchDataDTO()
+        parentPatch.isMergeConflict = this.isMergeConflict
+        parentPatch._type = this._type
+        parentPatch.path = this.path.parent
+
+        return parentPatch
+    }
+}

--- a/mauro-client/src/main/groovy/org/maurodata/api/model/MergeDiffDTO.groovy
+++ b/mauro-client/src/main/groovy/org/maurodata/api/model/MergeDiffDTO.groovy
@@ -16,14 +16,14 @@ diffs:
     String path
     String label
     Integer count
-    Integer getCount()
-    {
-        if(diffs==null){count=0; return count}
-        count=diffs.size()
+
+    Integer getCount() {
+        if (diffs == null) {count = 0; return count}
+        count = diffs.size()
         return count
     }
-    private void setCount(Integer count)
-    {
+
+    private void setCount(Integer count) {
         // Nope
     }
     List<MergeFieldDiffDTO> diffs

--- a/mauro-client/src/main/groovy/org/maurodata/api/model/MergeFieldDiffDTO.groovy
+++ b/mauro-client/src/main/groovy/org/maurodata/api/model/MergeFieldDiffDTO.groovy
@@ -1,6 +1,6 @@
 package org.maurodata.api.model
 
-import com.fasterxml.jackson.annotation.JsonAlias
+import com.fasterxml.jackson.annotation.JsonProperty
 
 class MergeFieldDiffDTO {
 
@@ -10,6 +10,6 @@ class MergeFieldDiffDTO {
     Object targetValue
     Object commonAncestorValue
     boolean isMergeConflict
-    @JsonAlias(['type'])
+    @JsonProperty('type')
     String _type
 }

--- a/mauro-client/src/main/groovy/org/maurodata/api/model/MergeIntoDTO.groovy
+++ b/mauro-client/src/main/groovy/org/maurodata/api/model/MergeIntoDTO.groovy
@@ -1,0 +1,8 @@
+package org.maurodata.api.model
+
+class MergeIntoDTO {
+
+    ObjectPatchDataDTO patch
+    boolean deleteBranch = false
+    String changeNotice
+}

--- a/mauro-client/src/main/groovy/org/maurodata/api/model/ObjectPatchDataDTO.groovy
+++ b/mauro-client/src/main/groovy/org/maurodata/api/model/ObjectPatchDataDTO.groovy
@@ -1,0 +1,9 @@
+package org.maurodata.api.model
+
+class ObjectPatchDataDTO {
+
+    UUID sourceId
+    UUID targetId
+    String label
+    List<FieldPatchDataDTO> patches = []
+}

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/classifier/ClassificationScheme.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/classifier/ClassificationScheme.groovy
@@ -81,4 +81,13 @@ class ClassificationScheme extends Model {
         }
     }
 
+    @Override
+    @JsonIgnore
+    @Transient
+    String getDiffIdentifier() {
+        if(folder!=null) {
+            return "${folder.getDiffIdentifier()}|${getPathNodeString()}"
+        }
+        return "${getPathNodeString()}"
+    }
 }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/classifier/Classifier.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/classifier/Classifier.groovy
@@ -84,21 +84,22 @@ class Classifier extends ModelItem<ClassificationScheme> implements DiffableItem
     @JsonIgnore
     @Transient
     CollectionDiff fromItem() {
-        new BaseCollectionDiff(id, label)
+        new BaseCollectionDiff(id, getDiffIdentifier(), label)
     }
 
     @Override
     @JsonIgnore
     @Transient
     String getDiffIdentifier() {
-        if (!parentClassifier) return this.pathIdentifier
-        "${parentClassifier.getDiffIdentifier()}/${this.pathIdentifier}"
+        if (parentClassifier != null) {return "${parentClassifier.getDiffIdentifier()}|${getPathNodeString()}"}
+        if (classificationScheme != null) {return "${classificationScheme.getDiffIdentifier()}|${getPathNodeString()}"}
+        return "${getPathNodeString()}"
     }
 
     @Override
     @JsonIgnore
     @Transient
-    ObjectDiff<Classifier> diff(Classifier other) {
+    ObjectDiff<Classifier> diff(Classifier other, String lhsPathRoot, String rhsPathRoot) {
         ObjectDiff<Classifier> base = DiffBuilder.objectDiff(Classifier)
                 .leftHandSide(id?.toString(), this)
                 .rightHandSide(other.id?.toString(), other)
@@ -106,7 +107,7 @@ class Classifier extends ModelItem<ClassificationScheme> implements DiffableItem
         base.appendString(DiffBuilder.DESCRIPTION, this.description, other.description, this, other)
         base.appendString(DiffBuilder.ALIASES_STRING, this.aliasesString, other.aliasesString, this, other)
         if (!DiffBuilder.isNullOrEmpty(this.classifiers as Collection<Object>) || !DiffBuilder.isNullOrEmpty(other.classifiers as Collection<Object>)) {
-            base.appendCollection(DiffBuilder.CLASSIFIERS, this.classifiers as Collection<DiffableItem>, other.classifiers as Collection<DiffableItem>)
+            base.appendCollection(DiffBuilder.CLASSIFIERS, this.classifiers as Collection<DiffableItem>, other.classifiers as Collection<DiffableItem>, lhsPathRoot, rhsPathRoot)
         }
         base
     }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/EnumerationValue.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/EnumerationValue.groovy
@@ -89,20 +89,26 @@ class EnumerationValue extends ModelItem<DataModel> implements DiffableItem<Enum
     @Transient
     @JsonIgnore
     CollectionDiff fromItem() {
-        new BaseCollectionDiff(id,label)
+        new BaseCollectionDiff(id,getDiffIdentifier(), label)
     }
 
     @Override
     @Transient
     @JsonIgnore
     String getDiffIdentifier() {
-        this.key
+        if (enumerationType != null) {
+            return "${enumerationType.getDiffIdentifier()}|${getPathNodeString()}"
+        }
+        if (dataModel != null) {
+            return "${dataModel.getDiffIdentifier()}|${getPathNodeString()}"
+        }
+        return "${getPathNodeString()}"
     }
 
     @Override
     @Transient
     @JsonIgnore
-    ObjectDiff<EnumerationValue> diff(EnumerationValue other) {
+    ObjectDiff<EnumerationValue> diff(EnumerationValue other, String lhsPathRoot, String rhsPathRoot) {
         ObjectDiff<EnumerationValue> base = DiffBuilder.objectDiff(EnumerationValue)
                 .leftHandSide(id?.toString(), this)
                 .rightHandSide(other.id?.toString(), other)

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/ReferenceType.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/ReferenceType.groovy
@@ -32,18 +32,19 @@ class ReferenceType extends ModelItem<DataType> implements DiffableItem<Referenc
 
     @Override
     CollectionDiff fromItem() {
-        new BaseCollectionDiff(id, label)
+        new BaseCollectionDiff(id, getDiffIdentifier(), label)
     }
 
     @Override
     String getDiffIdentifier() {
-        this.label
+        // TODO: Not sure what the path to this is supposed to be
+        getPathNodeString()
     }
 
     @Override
     @JsonIgnore
     @Transient
-    ObjectDiff<ReferenceType> diff(ReferenceType other) {
+    ObjectDiff<ReferenceType> diff(ReferenceType other, String lhsPathRoot, String rhsPathRoot) {
         ObjectDiff<ReferenceType> base = DiffBuilder.objectDiff(ReferenceType)
             .leftHandSide(id?.toString(), this)
             .rightHandSide(other.id?.toString(), other)

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/diff/ArrayDiff.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/diff/ArrayDiff.groovy
@@ -49,6 +49,39 @@ class ArrayDiff<K> extends FieldDiff<Collection<K>> {
     Integer getNumberOfDiffs() {
         created.size() + deleted.size() + ((modified.sum {it.getNumberOfDiffs() } ?: 0) as Integer)
     }
+
+    @Override
+    String toString(){
+        String description="\n<ArrayDiff> <super>"+super.toString()+"</super> ";
+
+        if (created.size() > 0) {
+            description += "<created> "
+            created.forEach {
+                description += it.getClass().simpleName+":"+it.toString() + ", "
+            }
+            description += " </created>"
+        }
+
+        if (deleted.size() > 0) {
+            description += "<deleted> "
+            deleted.forEach {
+                description += it.toString() + ", "
+            }
+            description += " </deleted>"
+        }
+
+        if (modified.size() > 0) {
+            description += "<modified> "
+            modified.forEach {
+                description += it.toString() + ", "
+            }
+            description += " </modified>"
+        }
+
+        description+="</ArrayDiff>"
+
+        return description
+    }
 }
 
 

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/diff/BaseCollectionDiff.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/diff/BaseCollectionDiff.groovy
@@ -4,17 +4,21 @@ import groovy.transform.CompileStatic
 import io.micronaut.core.annotation.Nullable
 
 @CompileStatic
-class BaseCollectionDiff extends CollectionDiff {
+class BaseCollectionDiff<F> extends CollectionDiff {
 
     @Nullable
     String label
 
-    BaseCollectionDiff(UUID id) {
-        super(id)
+    BaseCollectionDiff(UUID id, String diffIdentifier) {
+        super(id, diffIdentifier)
     }
 
-    BaseCollectionDiff(UUID id, @Nullable String label) {
-        super(id)
+    BaseCollectionDiff(UUID id, String diffIdentifier, @Nullable String label) {
+        super(id, diffIdentifier)
         this.label = label
+    }
+
+    String toString(){
+        return "<BaseCollectionDiff> "+label+" <super>"+super.toString()+"</super></BaseCollectionDiff>"
     }
 }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/diff/CollectionDTO.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/diff/CollectionDTO.groovy
@@ -8,7 +8,7 @@ class CollectionDTO {
 
     void addField(String field, Collection<DiffableItem> collection) {
         if (collection.size() > 0) {
-            fieldCollections.putIfAbsent(field, collection.unique())
+            fieldCollections.putIfAbsent(field, collection)
         }
     }
 

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/diff/CollectionDiff.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/diff/CollectionDiff.groovy
@@ -1,12 +1,21 @@
 package org.maurodata.domain.diff
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import groovy.transform.CompileStatic
 
 @CompileStatic
 abstract class CollectionDiff {
     UUID id
 
-    CollectionDiff(UUID id) {
+    @JsonIgnore
+    String diffIdentifier
+
+    CollectionDiff(UUID id, String diffIdentifier) {
         this.id = id
+        this.diffIdentifier = diffIdentifier
+    }
+
+    String toString(){
+        return "<CollectionDiff> "+id?.toString()+" "+diffIdentifier+" </CollectionDiff>"
     }
 }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/diff/DiffableItem.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/diff/DiffableItem.groovy
@@ -5,7 +5,7 @@ trait DiffableItem<T extends DiffableItem> {
 
     abstract String getDiffIdentifier()
 
-    abstract ObjectDiff<T> diff(T other)
+    abstract ObjectDiff<T> diff(T other, String lhsPathRoot, String rhsPathRoot)
 
 
 }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/diff/DiffablePlaceholder.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/diff/DiffablePlaceholder.groovy
@@ -14,7 +14,7 @@ class DiffablePlaceholder implements DiffableItem{
     }
 
     @Override
-    ObjectDiff diff(DiffableItem other) {
+    ObjectDiff diff(DiffableItem other, String lhsPathRoot, String rhsPathRoot) {
         return null
     }
 

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/diff/FieldDiff.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/diff/FieldDiff.groovy
@@ -43,7 +43,7 @@ class FieldDiff<F> {
 
     String toString()
     {
-        return "FieldDiff: "+name+" left="+left+" right="+right+" lhsDiffableItem="+lhsDiffableItem+" rhsDiffableItem="+rhsDiffableItem
+        return "\n<FieldDiff> "+name+"\n left="+left+"\n right="+right+"\n lhsDiffableItem="+lhsDiffableItem+"\n rhsDiffableItem="+rhsDiffableItem+"</FieldDiff>"
     }
 
 }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/diff/MetadataDiff.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/diff/MetadataDiff.groovy
@@ -9,8 +9,8 @@ class MetadataDiff extends CollectionDiff{
     String key
     String value
 
-    MetadataDiff(UUID id, String namespace, String key, String value) {
-        super(id)
+    MetadataDiff(UUID id, String namespace, String key, String value, String diffIdentifier) {
+        super(id,diffIdentifier)
         this.namespace = namespace
         this.key = key
         this.value = value

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/diff/RuleDiff.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/diff/RuleDiff.groovy
@@ -8,8 +8,8 @@ class RuleDiff extends CollectionDiff{
     String name
     String description
 
-    RuleDiff(UUID id, String name, String description) {
-        super(id)
+    RuleDiff(UUID id, String name, String description, String diffIdentifier) {
+        super(id,diffIdentifier)
         this.name = name
         this.description = description
     }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/diff/RuleRepresentationDiff.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/diff/RuleRepresentationDiff.groovy
@@ -8,8 +8,8 @@ class RuleRepresentationDiff extends CollectionDiff {
     String language
     String representation
 
-    RuleRepresentationDiff(UUID id, String language, String representation) {
-        super(id)
+    RuleRepresentationDiff(UUID id, String language, String representation, String diffIdentifier) {
+        super(id,diffIdentifier)
         this.language = language
         this.representation = representation
     }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/diff/SummaryMetadataDiff.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/diff/SummaryMetadataDiff.groovy
@@ -12,8 +12,8 @@ class SummaryMetadataDiff extends CollectionDiff {
 
     Collection<SummaryMetadataReport> summaryMetadataReports
 
-    SummaryMetadataDiff(UUID id, SummaryMetadataType summaryMetadataType, String label, Collection<SummaryMetadataReport> summaryMetadataReports) {
-        super(id)
+    SummaryMetadataDiff(UUID id, SummaryMetadataType summaryMetadataType, String label, Collection<SummaryMetadataReport> summaryMetadataReports, String diffIdentifier) {
+        super(id,diffIdentifier)
         this.summaryMetadataType = summaryMetadataType
         this.label = label
         this.summaryMetadataReports = summaryMetadataReports

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/diff/SummaryMetadataReportDiff.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/diff/SummaryMetadataReportDiff.groovy
@@ -13,8 +13,8 @@ class SummaryMetadataReportDiff extends CollectionDiff {
     @NonNull
     String reportValue
 
-    SummaryMetadataReportDiff(UUID id, @Nullable Instant reportDate, @NonNull String reportValue) {
-        super(id)
+    SummaryMetadataReportDiff(UUID id, @Nullable Instant reportDate, @NonNull String reportValue, String diffIdentifier) {
+        super(id, diffIdentifier)
         this.reportDate = reportDate
         this.reportValue = reportValue
     }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/facet/CatalogueFile.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/facet/CatalogueFile.groovy
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import groovy.transform.AutoClone
 import groovy.transform.CompileStatic
 import io.micronaut.core.annotation.NonNull
+import io.micronaut.data.annotation.Transient
 
 @CompileStatic
 @AutoClone
@@ -27,5 +28,18 @@ abstract class CatalogueFile extends Facet implements CatalogueFileOutput{
     @JsonAlias(['file_type'])
     String fileType
 
+    @Transient
+    @JsonIgnore
+    @Override
+    String getPathPrefix() {
+        'cf'
+    }
 
+    //TODO: Not clean: fileName may contain characters used by Paths
+    @Transient
+    @JsonIgnore
+    @Override
+    String getPathIdentifier() {
+        fileName
+    }
 }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/facet/Edit.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/facet/Edit.groovy
@@ -1,11 +1,13 @@
 package org.maurodata.domain.facet
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import groovy.transform.AutoClone
 import groovy.transform.CompileStatic
 import groovy.transform.MapConstructor
 import io.micronaut.data.annotation.Index
 import io.micronaut.data.annotation.Indexes
 import io.micronaut.data.annotation.MappedEntity
+import io.micronaut.data.annotation.Transient
 
 @CompileStatic
 @MappedEntity(schema = 'core')
@@ -53,4 +55,17 @@ class Edit extends Facet {
         this.description
     }
 
+    @Transient
+    @JsonIgnore
+    @Override
+    String getPathPrefix() {
+        'ed'
+    }
+
+    @Transient
+    @JsonIgnore
+    @Override
+    String getPathIdentifier() {
+        title
+    }
 }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/facet/EditType.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/facet/EditType.groovy
@@ -25,7 +25,8 @@ enum EditType {
     FINALISE,
     CHANGELOG,
     VIEW,
-    EXPORT
+    EXPORT,
+    CHANGENOTICE
 
     static class EditTypeConverter extends StdConverter<String, EditType> {
 

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/facet/Facet.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/facet/Facet.groovy
@@ -1,17 +1,21 @@
 package org.maurodata.domain.facet
 
+import org.maurodata.domain.model.Path
+import org.maurodata.domain.model.Pathable
+
 import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import groovy.transform.AutoClone
 import groovy.transform.CompileStatic
+import io.micronaut.core.annotation.Nullable
 import jakarta.persistence.Transient
 import org.maurodata.domain.model.AdministeredItem
 import org.maurodata.domain.model.Item
 
 @CompileStatic
 @AutoClone
-abstract class Facet extends Item {
+abstract class Facet extends Item implements Pathable {
 
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     @JsonAlias(['multi_facet_aware_item_domain_type'])
@@ -28,4 +32,21 @@ abstract class Facet extends Item {
     @Transient
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     String domainType = this.class.simpleName
+
+    /**
+     * Get this item's PathNode String
+     */
+    @Transient
+    @JsonIgnore
+    String getPathNodeString() {
+        (new Path.PathNode(prefix: this.pathPrefix, identifier: this.pathIdentifier, modelIdentifier: this.pathModelIdentifier)).toString()
+    }
+
+    @Transient
+    @JsonIgnore
+    @Override
+    @Nullable
+    String getPathModelIdentifier() {
+        return null
+    }
 }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/facet/Metadata.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/facet/Metadata.groovy
@@ -32,7 +32,7 @@ class Metadata extends Facet implements DiffableItem<Metadata> {
     @JsonIgnore
     @Transient
     CollectionDiff fromItem() {
-        new MetadataDiff(id, namespace, key, value)
+        new MetadataDiff(id, namespace, key, value, getDiffIdentifier())
     }
 
 
@@ -40,13 +40,16 @@ class Metadata extends Facet implements DiffableItem<Metadata> {
     @JsonIgnore
     @Transient
     String getDiffIdentifier() {
-        "${this.namespace}.${this.key}"
+        if (multiFacetAwareItem != null) {
+            return "${multiFacetAwareItem.getDiffIdentifier()}|${pathPrefix}:${this.namespace}.${this.key}"
+        }
+        return "${pathPrefix}:${this.namespace}.${this.key}"
     }
 
     @Override
     @JsonIgnore
     @Transient
-    ObjectDiff<Metadata> diff(Metadata other) {
+    ObjectDiff<Metadata> diff(Metadata other, String lhsPathRoot, String rhsPathRoot) {
         ObjectDiff od = DiffBuilder.objectDiff(Metadata)
                 .leftHandSide(id?.toString(), this)
                 .rightHandSide(other.id?.toString(), other)
@@ -101,5 +104,17 @@ class Metadata extends Facet implements DiffableItem<Metadata> {
         this.value
     }
 
+    @Transient
+    @JsonIgnore
+    @Override
+    String getPathPrefix() {
+        'md'
+    }
 
+    @Transient
+    @JsonIgnore
+    @Override
+    String getPathIdentifier() {
+        "${this.namespace}.${this.key}"
+    }
 }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/facet/ReferenceFile.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/facet/ReferenceFile.groovy
@@ -38,24 +38,45 @@ class ReferenceFile extends CatalogueFile implements DiffableItem<ReferenceFile>
     @Transient
     @JsonIgnore
     CollectionDiff fromItem() {
-        new BaseCollectionDiff(id)
+        new BaseCollectionDiff(id,getDiffIdentifier(),null)
     }
 
     @Override
     @Transient
     @JsonIgnore
     String getDiffIdentifier() {
-        fileName
+        "${pathPrefix}:${fileName}"
     }
 
     @Override
     @Transient
     @JsonIgnore
-    ObjectDiff<ReferenceFile> diff(ReferenceFile other) {
+    ObjectDiff<ReferenceFile> diff(ReferenceFile other, String lhsPathRoot, String rhsPathRoot) {
         ObjectDiff<ReferenceFile> base = DiffBuilder.objectDiff(ReferenceFile)
                 .leftHandSide(id?.toString(), this)
                 .rightHandSide(other.id?.toString(), other)
         base.appendString(DiffBuilder.FILE_NAME, this.fileName, other.fileName, this, other)
         base
+    }
+
+    @Transient
+    @JsonIgnore
+    ObjectDiff<ReferenceFile> diff(ReferenceFile other) {
+        diff(other, null, null)
+    }
+
+    @Transient
+    @JsonIgnore
+    @Override
+    String getPathPrefix() {
+        'rf'
+    }
+
+    //TODO: Not clean: fileName may contain characters used by Paths
+    @Transient
+    @JsonIgnore
+    @Override
+    String getPathIdentifier() {
+        fileName
     }
 }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/facet/Rule.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/facet/Rule.groovy
@@ -41,27 +41,28 @@ class Rule extends Facet implements DiffableItem<Rule> {
     @JsonIgnore
     @Transient
     CollectionDiff fromItem() {
-        new RuleDiff(id, name, description)
+        new RuleDiff(id, name, description, getDiffIdentifier())
     }
 
     @Override
     @JsonIgnore
     @Transient
     String getDiffIdentifier() {
-        name
+        if (multiFacetAwareItem != null) {return "${multiFacetAwareItem.getDiffIdentifier()}|${pathPrefix}:${name}"}
+        return "${pathPrefix}:${name}"
     }
 
     @Override
     @JsonIgnore
     @Transient
-    ObjectDiff<Rule> diff(Rule other) {
+    ObjectDiff<Rule> diff(Rule other, String lhsPathRoot, String rhsPathRoot) {
         ObjectDiff<Rule> base = DiffBuilder.objectDiff(Rule)
                 .leftHandSide(id?.toString(), this)
                 .rightHandSide(other.id?.toString(), other)
         base.label = this.name
         base.appendString(DiffBuilder.DESCRIPTION, this.description, other.description, this, other)
         if (!DiffBuilder.isNull(this.ruleRepresentations) ||!DiffBuilder.isNull(other.ruleRepresentations)) {
-            base.appendCollection(DiffBuilder.SUMMARY_METADATA_REPORT, this.ruleRepresentations as Collection<DiffableItem>, other.ruleRepresentations as Collection<DiffableItem>)
+            base.appendCollection(DiffBuilder.SUMMARY_METADATA_REPORT, this.ruleRepresentations as Collection<DiffableItem>, other.ruleRepresentations as Collection<DiffableItem>, lhsPathRoot, rhsPathRoot)
         }
         base
     }
@@ -116,5 +117,17 @@ class Rule extends Facet implements DiffableItem<Rule> {
         ruleRepresentation [:], closure
     }
 
+    @Transient
+    @JsonIgnore
+    @Override
+    String getPathPrefix() {
+        'ru'
+    }
 
+    @Transient
+    @JsonIgnore
+    @Override
+    String getPathIdentifier() {
+       name
+    }
 }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/facet/RuleRepresentation.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/facet/RuleRepresentation.groovy
@@ -6,12 +6,14 @@ import org.maurodata.domain.diff.DiffableItem
 import org.maurodata.domain.diff.ObjectDiff
 import org.maurodata.domain.diff.RuleRepresentationDiff
 import org.maurodata.domain.model.Item
+import org.maurodata.domain.model.Pathable
 
 import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonIgnore
 import groovy.transform.AutoClone
 import groovy.transform.CompileStatic
 import groovy.transform.MapConstructor
+import io.micronaut.core.annotation.Nullable
 import io.micronaut.data.annotation.MappedEntity
 import io.micronaut.data.annotation.Transient
 
@@ -19,7 +21,7 @@ import io.micronaut.data.annotation.Transient
 @MappedEntity(value = 'rule_representation', schema = 'core', alias = 'rule_representation_')
 @AutoClone
 @MapConstructor(includeSuperFields = true, includeSuperProperties = true, noArg = true)
-class RuleRepresentation extends Item implements DiffableItem<RuleRepresentation> {
+class RuleRepresentation extends Item implements DiffableItem<RuleRepresentation>, Pathable {
     String language
 
     String representation
@@ -31,20 +33,20 @@ class RuleRepresentation extends Item implements DiffableItem<RuleRepresentation
     @JsonIgnore
     @Transient
     CollectionDiff fromItem() {
-        new RuleRepresentationDiff(id, language, representation)
+        new RuleRepresentationDiff(id, language, representation, getDiffIdentifier())
     }
 
     @Override
     @JsonIgnore
     @Transient
     String getDiffIdentifier() {
-        language
+        return "${pathPrefix}:${language}"
     }
 
     @Override
     @JsonIgnore
     @Transient
-    ObjectDiff<RuleRepresentation> diff(RuleRepresentation other) {
+    ObjectDiff<RuleRepresentation> diff(RuleRepresentation other, String lhsPathRoot, String rhsPathRoot) {
         ObjectDiff<RuleRepresentation> base = DiffBuilder.objectDiff(RuleRepresentation)
                 .leftHandSide(id?.toString(), this)
                 .rightHandSide(other.id?.toString(), other)
@@ -89,4 +91,25 @@ class RuleRepresentation extends Item implements DiffableItem<RuleRepresentation
         this.representation
     }
 
+    @Transient
+    @JsonIgnore
+    @Override
+    String getPathPrefix() {
+        'rr'
+    }
+
+    @Transient
+    @JsonIgnore
+    @Override
+    String getPathIdentifier() {
+        language
+    }
+
+    @Transient
+    @JsonIgnore
+    @Override
+    @Nullable
+    String getPathModelIdentifier() {
+        return null
+    }
 }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/facet/SemanticLink.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/facet/SemanticLink.groovy
@@ -1,19 +1,24 @@
 package org.maurodata.domain.facet
 
+import org.maurodata.domain.model.ItemReference
+import org.maurodata.domain.model.ItemReferencer
+
 import com.fasterxml.jackson.annotation.JsonAlias
+import com.fasterxml.jackson.annotation.JsonIgnore
 import groovy.transform.AutoClone
 import groovy.transform.CompileStatic
 import groovy.transform.MapConstructor
 import io.micronaut.data.annotation.Index
 import io.micronaut.data.annotation.Indexes
 import io.micronaut.data.annotation.MappedEntity
+import io.micronaut.data.annotation.Transient
 
 @CompileStatic
 @MappedEntity(schema = 'core')
 @AutoClone
 @Indexes([@Index(columns = ['multi_facet_aware_item_id'], unique = true)])
 @MapConstructor(includeSuperFields = true, includeSuperProperties = true, noArg = true)
-class SemanticLink extends Facet {
+class SemanticLink extends Facet implements ItemReferencer {
 
     @JsonAlias(['link_type'])
     SemanticLinkType linkType
@@ -25,5 +30,40 @@ class SemanticLink extends Facet {
 
     SemanticLink() {
         unconfirmed = false
+    }
+
+    @Transient
+    @JsonIgnore
+    @Override
+    String getPathPrefix() {
+        'sl'
+    }
+
+    @Transient
+    @JsonIgnore
+    @Override
+    String getPathIdentifier() {
+        "${linkType}.${targetMultiFacetAwareItemDomainType}.${targetMultiFacetAwareItemId}"
+    }
+
+    @Transient
+    @JsonIgnore
+    @Override
+    List<ItemReference> getItemReferences() {
+        List<ItemReference> pathsBeingReferenced = []
+        if (targetMultiFacetAwareItemId != null) {
+            pathsBeingReferenced << ItemReference.from(targetMultiFacetAwareItemId,targetMultiFacetAwareItemDomainType)
+        }
+        return pathsBeingReferenced
+    }
+
+    @Override
+    void replaceItemReferences(Map<UUID, ItemReference> replacements) {
+        if (targetMultiFacetAwareItemId != null) {
+            ItemReference replacementItemReference = replacements.get(targetMultiFacetAwareItemId)
+            if (replacementItemReference != null) {
+                targetMultiFacetAwareItemId = replacementItemReference.itemId
+            }
+        }
     }
 }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/facet/SummaryMetadata.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/facet/SummaryMetadata.groovy
@@ -36,20 +36,21 @@ class SummaryMetadata extends Facet implements DiffableItem<SummaryMetadata> {
     @JsonIgnore
     @Transient
     CollectionDiff fromItem() {
-        new SummaryMetadataDiff(id, summaryMetadataType, label, summaryMetadataReports)
+        new SummaryMetadataDiff(id, summaryMetadataType, label, summaryMetadataReports, getDiffIdentifier())
     }
 
     @Override
     @JsonIgnore
     @Transient
     String getDiffIdentifier() {
-        label
+        if(multiFacetAwareItem != null){return "${multiFacetAwareItem.getDiffIdentifier()}|${this.pathNodeString}"}
+        return "${this.pathNodeString}"
     }
 
     @Override
     @JsonIgnore
     @Transient
-    ObjectDiff<SummaryMetadata> diff(SummaryMetadata other) {
+    ObjectDiff<SummaryMetadata> diff(SummaryMetadata other, String lhsPathRoot, String rhsPathRoot) {
         ObjectDiff<SummaryMetadata> base = DiffBuilder.objectDiff(SummaryMetadata)
                 .leftHandSide(id?.toString(), this)
                 .rightHandSide(other.id?.toString(), other)
@@ -57,7 +58,7 @@ class SummaryMetadata extends Facet implements DiffableItem<SummaryMetadata> {
         base.appendString(DiffBuilder.DESCRIPTION, this.description, other.description, this, other)
         base.appendString(DiffBuilder.SUMMARY_METADATA_TYPE, this.summaryMetadataType.name(), other.summaryMetadataType.name(), this, other)
         if (!DiffBuilder.isNull(this.summaryMetadataReports) ||!DiffBuilder.isNull(other.summaryMetadataReports)) {
-            base.appendCollection(DiffBuilder.SUMMARY_METADATA_REPORT, this.summaryMetadataReports as Collection<DiffableItem>, other.summaryMetadataReports as Collection<DiffableItem>)
+            base.appendCollection(DiffBuilder.SUMMARY_METADATA_REPORT, this.summaryMetadataReports as Collection<DiffableItem>, other.summaryMetadataReports as Collection<DiffableItem>, lhsPathRoot, rhsPathRoot)
         }
         base
     }
@@ -122,4 +123,17 @@ class SummaryMetadata extends Facet implements DiffableItem<SummaryMetadata> {
         summaryMetadataReport [:], closure
     }
 
+    @Transient
+    @JsonIgnore
+    @Override
+    String getPathPrefix() {
+        'sm'
+    }
+
+    @Transient
+    @JsonIgnore
+    @Override
+    String getPathIdentifier() {
+        label
+    }
 }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/facet/SummaryMetadataReport.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/facet/SummaryMetadataReport.groovy
@@ -6,6 +6,7 @@ import org.maurodata.domain.diff.DiffableItem
 import org.maurodata.domain.diff.ObjectDiff
 import org.maurodata.domain.diff.SummaryMetadataReportDiff
 import org.maurodata.domain.model.Item
+import org.maurodata.domain.model.Pathable
 
 import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonIgnore
@@ -18,12 +19,13 @@ import io.micronaut.data.annotation.MappedEntity
 import io.micronaut.data.annotation.Transient
 
 import java.time.Instant
+import java.time.format.DateTimeFormatter
 
 @CompileStatic
 @MappedEntity(value = 'summary_metadata_report', schema = 'core', alias = 'summary_metadata_report_')
 @AutoClone
 @MapConstructor(includeSuperFields = true, includeSuperProperties = true, noArg = true)
-class SummaryMetadataReport extends Item implements DiffableItem<SummaryMetadataReport> {
+class SummaryMetadataReport extends Item implements DiffableItem<SummaryMetadataReport>, Pathable {
     @JsonAlias(['report_value'])
     @NonNull
     String reportValue
@@ -40,20 +42,20 @@ class SummaryMetadataReport extends Item implements DiffableItem<SummaryMetadata
     @JsonIgnore
     @Transient
     CollectionDiff fromItem() {
-        new SummaryMetadataReportDiff(id, reportDate, reportValue)
+        new SummaryMetadataReportDiff(id, reportDate, reportValue, getDiffIdentifier())
     }
 
     @Override
     @JsonIgnore
     @Transient
     String getDiffIdentifier() {
-        reportValue
+        return "${pathPrefix}:${reportValue}"
     }
 
     @Override
     @JsonIgnore
     @Transient
-    ObjectDiff<SummaryMetadataReport> diff(SummaryMetadataReport other) {
+    ObjectDiff<SummaryMetadataReport> diff(SummaryMetadataReport other, String lhsPathRoot, String rhsPathRoot) {
         ObjectDiff<SummaryMetadataReport> base = DiffBuilder.objectDiff(SummaryMetadataReport)
                 .leftHandSide(id?.toString(), this)
                 .rightHandSide(other.id?.toString(), other)
@@ -99,4 +101,26 @@ class SummaryMetadataReport extends Item implements DiffableItem<SummaryMetadata
         this.reportDate
     }
 
+    @Transient
+    @JsonIgnore
+    @Override
+    String getPathPrefix() {
+        'smr'
+    }
+
+    @Transient
+    @JsonIgnore
+    @Override
+    String getPathIdentifier() {
+        if(reportDate != null) {return reportDate.toString()}
+        return "-"
+    }
+
+    @Transient
+    @JsonIgnore
+    @Override
+    @Nullable
+    String getPathModelIdentifier() {
+        return null
+    }
 }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/folder/Folder.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/folder/Folder.groovy
@@ -104,13 +104,13 @@ class Folder extends Model {
     String author
 
     // TODO: write a test for branch name
-    @Nullable
-    String branchName = 'main'
+
+    @Override
     String getBranchName()
     {
         if(this.class_!=null && "VersionedFolder" == this.class_)
         {
-            return branchName
+            return super.branchName
         }
         else
         {
@@ -187,6 +187,7 @@ class Folder extends Model {
     @Override
     @Transient
     @JsonIgnore
+    @Nullable
     String getPathModelIdentifier() {
         if(!isVersionable())
         {
@@ -194,6 +195,13 @@ class Folder extends Model {
         }
         // I'm a model, you know what I mean
         return super.getPathModelIdentifier()
+    }
+
+    @Transient
+    @JsonIgnore
+    String getDiffIdentifier() {
+        if (parentFolder != null) {return "${parentFolder.getDiffIdentifier()}|${getPathNodeString()}"}
+        return "${getPathNodeString()}"
     }
 
     @Override

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/model/AdministeredItem.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/model/AdministeredItem.groovy
@@ -3,6 +3,7 @@ package org.maurodata.domain.model
 import org.maurodata.domain.classifier.Classifier
 import org.maurodata.domain.facet.Annotation
 import org.maurodata.domain.facet.Edit
+import org.maurodata.domain.facet.Facet
 import org.maurodata.domain.facet.Metadata
 import org.maurodata.domain.facet.ReferenceFile
 import org.maurodata.domain.facet.Rule
@@ -35,7 +36,7 @@ import java.time.Instant
 
 @CompileStatic
 @AutoClone
-abstract class AdministeredItem extends Item {
+abstract class AdministeredItem extends Item implements Pathable {
 
     /**
      * The label of an object.  Labels are used as identifiers within a context and so need to be unique within
@@ -168,8 +169,26 @@ abstract class AdministeredItem extends Item {
      */
     @Transient
     @JsonIgnore
+    @Override
+    @Nullable
     String getPathModelIdentifier() {
-        null
+        return null
+    }
+
+    /**
+     * Get this item's PathNode String
+     */
+    @Transient
+    @JsonIgnore
+    String getPathNodeString() {
+        (new Path.PathNode(prefix: this.pathPrefix, identifier: this.pathIdentifier, modelIdentifier: this.pathModelIdentifier)).toString()
+    }
+
+    @JsonIgnore
+    @Transient
+    String getDiffIdentifier() {
+        if (parent != null) {return "${parent.getDiffIdentifier()}|${this.pathNodeString}"}
+        return pathNodeString
     }
 
     /**

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/model/ItemReference.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/model/ItemReference.groovy
@@ -1,0 +1,44 @@
+package org.maurodata.domain.model
+
+import groovy.transform.CompileStatic
+import groovy.transform.Immutable
+import groovy.transform.ImmutableOptions
+
+/**
+ * An abstracted reference to an Item or an AdministeredItem
+ * that can be used to resolve the Item
+ */
+@CompileStatic
+class ItemReference {
+
+    Path pathToItem
+    UUID itemId
+    String itemDomainType
+
+    Item theItem
+
+    static ItemReference from(final Item item) {
+        if (item instanceof AdministeredItem) {
+            return new ItemReference(pathToItem: item.path, itemId: item.id, itemDomainType: item.domainType, theItem: item)
+        }
+        return new ItemReference(pathToItem: null, itemId: item.id, itemDomainType: item.domainType, theItem: item)
+    }
+
+    static ItemReference from(final Path path) {
+        return new ItemReference(pathToItem: new Path(path.toString()), itemId: null, itemDomainType: null, theItem: null)
+    }
+
+    static ItemReference from(final UUID id, final String domainType) {
+        return new ItemReference(pathToItem: null, itemId: id, itemDomainType: domainType, theItem: null)
+    }
+
+    @Override
+    String toString() {
+        String referenceTo = "ItemReference to"
+        if (pathToItem != null) {referenceTo += " " + pathToItem.toString()}
+        if (itemId != null) {referenceTo += " " + itemId.toString()}
+        if (itemDomainType != null) {referenceTo += " " + itemDomainType.toString()}
+        referenceTo += " " + hashCode()
+        return referenceTo
+    }
+}

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/model/ItemReferencer.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/model/ItemReferencer.groovy
@@ -1,0 +1,24 @@
+package org.maurodata.domain.model
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import jakarta.persistence.Transient
+
+/**
+Any item in the model that holds references to other items
+should implement ItemReferencer
+ */
+interface ItemReferencer {
+    /**
+     * The list of ItemReference this holds references to
+     */
+    @Transient
+    @JsonIgnore
+    List<ItemReference> getItemReferences()
+
+    /**
+     * A map of ItemReference to replace with new references
+     */
+    @Transient
+    @JsonIgnore
+    void replaceItemReferences(final Map<UUID, ItemReference> replacements)
+}

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/model/Model.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/model/Model.groovy
@@ -1,5 +1,7 @@
 package org.maurodata.domain.model
 
+import org.maurodata.domain.datamodel.DataModel
+
 import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonIgnore
 import groovy.transform.CompileStatic
@@ -71,7 +73,7 @@ abstract class Model<M extends DiffableItem> extends AdministeredItem implements
     Authority authority
 
     @Nullable
-    String branchName = DEFAULT_BRANCH_NAME
+    protected String branchName = DEFAULT_BRANCH_NAME
 
     @Nullable
     //@Transient
@@ -134,6 +136,7 @@ abstract class Model<M extends DiffableItem> extends AdministeredItem implements
     @Override
     @Transient
     @JsonIgnore
+    @Nullable
     String getPathModelIdentifier() {
         final Model model=getModelWithVersion()
 
@@ -172,6 +175,7 @@ abstract class Model<M extends DiffableItem> extends AdministeredItem implements
         }
         CollectionDTO lhs = DiffBuilder.createCollectionDiff(DiffBuilder.MODEL_COLLECTION_KEYS, this.properties)
         CollectionDTO rhs = DiffBuilder.createCollectionDiff(DiffBuilder.MODEL_COLLECTION_KEYS, other.properties)
+
         ObjectDiff baseDiff = DiffBuilder.diff(this, other, lhs, rhs)
         baseDiff
     }
@@ -193,24 +197,15 @@ abstract class Model<M extends DiffableItem> extends AdministeredItem implements
 
     @JsonIgnore
     @Transient
-    Model getModelWithVersion()
-    {
-        final List<Model> myAncestors= getAncestors()
+    Model getModelWithVersion() {
+        final List<Model> myAncestors = getAncestors()
         Collections.reverse(myAncestors)
 
         // Ignoring folders that are not versionable, find an ancestor
         // that has a version
-
-        final Iterator<Model> it=myAncestors.iterator()
-        while(it.hasNext())
-        {
-            final Model model = it.next()
-            if(model instanceof Folder)
-            {
-                if(!model.@versionableFlag){continue}
-            }
-            if(model.@modelVersion!=null)
-            {
+        for (int m = 0; m < myAncestors.size(); m++) {
+            final Model model = myAncestors.get(m)
+            if ((model instanceof Folder || model instanceof DataModel) && model.@versionableFlag) {
                 return model
             }
         }
@@ -222,8 +217,11 @@ abstract class Model<M extends DiffableItem> extends AdministeredItem implements
         return getModelWithVersion().@modelVersion
     }
 
-    String getBranchName()
-    {
+    void setBranchName(final String branchNameString) {
+        this.@branchName = branchNameString;
+    }
+
+    String getBranchName() {
         return getModelWithVersion().@branchName
     }
 

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/model/ModelService.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/model/ModelService.groovy
@@ -33,7 +33,7 @@ abstract class ModelService<M extends Model> {
 
     M finaliseModel(M model, @Nullable ModelVersion requestedModelVersion, @Nullable VersionChangeType versionChangeType, @Nullable String versionTag) {
         if (!requestedModelVersion && !versionChangeType) throw new IllegalArgumentException('A version or versionChangeType must be specified to finalise a Model')
-        if (model.branchName != 'main') throw new MauroApplicationException("Cannot finalise Model [$model.label] as it is not on branch 'main'")
+        if (model.branchName != Model.DEFAULT_BRANCH_NAME) throw new MauroApplicationException("Cannot finalise Model [$model.label] as it is not on branch 'main'")
         if (model.finalised) throw new MauroApplicationException("Cannot finalise Model [$model.label] as it is already finalised")
 
         model.finalised = true

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/model/Pathable.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/model/Pathable.groovy
@@ -1,0 +1,30 @@
+package org.maurodata.domain.model
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import io.micronaut.core.annotation.Nullable
+import jakarta.persistence.Transient
+
+interface Pathable {
+
+    /**
+     * The prefix used in this item's Path, if this item is pathable.
+     */
+    @Transient
+    @JsonIgnore
+    String getPathPrefix()
+
+    /**
+     * The identifier (label) used in this item's Path, if this item is pathable.
+     */
+    @Transient
+    @JsonIgnore
+    String getPathIdentifier()
+
+    /**
+     * The model identifier (version string or branch label) used in this item's Path, if this item is pathable.
+     */
+    @Transient
+    @JsonIgnore
+    @Nullable
+    String getPathModelIdentifier()
+}

--- a/mauro-domain/src/main/groovy/org/maurodata/web/ListResponse.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/web/ListResponse.groovy
@@ -121,7 +121,6 @@ class ListResponse<T> {
         if (comparator == null) {
             // Couldn't resolve the sort field to use
             sorted = input
-            System.err.println("Warning: unable to sort")
         } else {
             sorted = input.toSorted(comparator)
         }

--- a/mauro-domain/src/test/groovy/org/maurodata/test/domain/datamodel/DataModelSpec.groovy
+++ b/mauro-domain/src/test/groovy/org/maurodata/test/domain/datamodel/DataModelSpec.groovy
@@ -21,15 +21,18 @@ class DataModelSpec extends Specification {
         primitiveType {
             label 'string'
             description 'character string'
+            id UUID.randomUUID()
         }
         primitiveType {
             label 'integer'
             description 'a whole number, may be positive or negative, with no maximum or minimum'
+            id UUID.randomUUID()
         }
         primitiveType {
             label 'height'
             units 'centimeters'
             description 'a whole number, may be positive or negative, with no maximum or minimum'
+            id UUID.randomUUID()
         }
         enumerationType {
             label 'Yes/No'
@@ -37,8 +40,10 @@ class DataModelSpec extends Specification {
             enumerationValue {
                 key 'Y'
                 value 'Yes'
+                id UUID.randomUUID()
             }
             enumerationValue(key: 'N', value: 'No')
+            id UUID.randomUUID()
         }
 
         dataClass {
@@ -69,6 +74,7 @@ class DataModelSpec extends Specification {
                     primitiveType {
                         label 'date'
                         description 'A date'
+                        id UUID.randomUUID()
                     }
                 }
             }
@@ -170,7 +176,8 @@ class DataModelSpec extends Specification {
         clonedDataClass1.extendedBy.size() == 1
         clonedDataClass1.extendedBy.first().is(clonedDataClass3)
 
-        cloned.dataElements.dataType == original.dataElements.dataType
+        cloned.dataElements.dataType.hashCode() != original.dataElements.dataType.hashCode()
+        cloned.dataElements.dataType.id == original.dataElements.dataType.id
         cloned.dataTypes.containsAll(cloned.dataElements.dataType)
         original.dataTypes.containsAll(original.dataElements.dataType)
 

--- a/mauro-domain/src/test/groovy/org/maurodata/test/domain/folder/FolderSpec.groovy
+++ b/mauro-domain/src/test/groovy/org/maurodata/test/domain/folder/FolderSpec.groovy
@@ -73,7 +73,8 @@ class FolderSpec extends Specification {
             folder.dataModels.allDataClasses
         }
 
-        cloned.dataModels.dataElements.dataType == folder.dataModels.dataElements.dataType
+        cloned.dataModels.dataElements.dataType.hashCode() != folder.dataModels.dataElements.dataType.hashCode()
+        cloned.dataModels.dataElements.dataType.id == folder.dataModels.dataElements.dataType.id
         cloned.dataModels.dataElements.dataType.toSet().each{
             cloned.dataModels.dataTypes.contains(it)
         }
@@ -84,13 +85,16 @@ class FolderSpec extends Specification {
         !cloned.dataModels.dataElements.dataType.is(folder.dataModels.dataElements.dataType)
 
         !cloned.terminologies.is(folder.terminologies)
-        cloned.terminologies.terms == folder.terminologies.terms
+        cloned.terminologies.terms.hashCode() != folder.terminologies.terms.hashCode()
+        cloned.terminologies.terms.id == folder.terminologies.terms.id
         !cloned.terminologies.terms.is(folder.terminologies.terms)
 
-        cloned.terminologies.termRelationshipTypes == folder.terminologies.termRelationshipTypes
+        cloned.terminologies.termRelationshipTypes.hashCode() != folder.terminologies.termRelationshipTypes.hashCode()
+        cloned.terminologies.termRelationshipTypes.id == folder.terminologies.termRelationshipTypes.id
         !cloned.terminologies.termRelationshipTypes.is(folder.terminologies.termRelationshipTypes)
 
-        cloned.terminologies.termRelationships == folder.terminologies.termRelationships
+        cloned.terminologies.termRelationships.hashCode() != folder.terminologies.termRelationships.hashCode()
+        cloned.terminologies.termRelationships.id == folder.terminologies.termRelationships.id
         !cloned.terminologies.termRelationships.is(folder.terminologies.termRelationships)
 
         folder.codeSets.size() == 1

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/authority/AuthorityRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/authority/AuthorityRepository.groovy
@@ -33,5 +33,9 @@ abstract class AuthorityRepository implements ItemRepository<Authority> {
         Authority
     }
 
+    // Does not have a prefix
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        false
+    }
 }
 

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/cache/AdministeredItemCacheableRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/cache/AdministeredItemCacheableRepository.groovy
@@ -46,6 +46,10 @@ abstract class AdministeredItemCacheableRepository<I extends AdministeredItem> e
         repository = itemRepository
     }
 
+    List<I> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier) {
+        repository.findAllByParentAndPathIdentifier( item,  pathIdentifier)
+    }
+
     List<I> findAllByParent(AdministeredItem parent) {
         cachedLookupByParent(FIND_ALL_BY_PARENT, domainType, parent)
     }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/cache/ItemCacheableRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/cache/ItemCacheableRepository.groovy
@@ -151,6 +151,10 @@ abstract class ItemCacheableRepository<I extends Item> implements ItemRepository
         repository.handles(domainType)
     }
 
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        repository.handlesPathPrefix(pathPrefix)
+    }
+
     // Cacheable Item Repository definitions
 
     @Singleton

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/classifier/ClassificationSchemeRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/classifier/ClassificationSchemeRepository.groovy
@@ -22,6 +22,11 @@ abstract class ClassificationSchemeRepository implements ModelRepository<Classif
         classificationSchemeDTORepository.findById(id) as ClassificationScheme
     }
 
+    @Nullable
+    List<ClassificationScheme> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier) {
+        classificationSchemeDTORepository.findAllByParentAndPathIdentifier(item,pathIdentifier) as List<ClassificationScheme>
+    }
+
     @Override
     Class getDomainClass() {
         ClassificationScheme
@@ -36,4 +41,8 @@ abstract class ClassificationSchemeRepository implements ModelRepository<Classif
     Boolean handles(String domainType){
         return domainType != null && domainType.toLowerCase() in [FieldConstants.CLASSIFICATION_SCHEME_LOWERCASE, FieldConstants.CLASSIFICATION_SCHEMES_LOWERCASE ]
     }
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        'csc'.equalsIgnoreCase(pathPrefix)
+    }
+
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/classifier/ClassifierContentRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/classifier/ClassifierContentRepository.groovy
@@ -23,4 +23,8 @@ class ClassifierContentRepository extends AdministeredItemContentRepository {
         classifier
     }
 
+    @Override
+    Boolean handles(Class clazz) {
+        return clazz.simpleName == 'Classifier'
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/classifier/ClassifierRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/classifier/ClassifierRepository.groovy
@@ -26,6 +26,12 @@ abstract class ClassifierRepository implements ModelItemRepository<Classifier> {
         classifierDTORepository.findById(id) as Classifier
     }
 
+    @Override
+    @Nullable
+    List<Classifier> findAllByParentAndPathIdentifier(UUID item,String pathIdentifier) {
+        classifierDTORepository.findAllByParentAndPathIdentifier(item,pathIdentifier) as List<Classifier>
+    }
+
     @Nullable
     List<Classifier> findAllByClassificationScheme(ClassificationScheme classificationScheme) {
         classifierDTORepository.findAllByClassificationScheme(classificationScheme) as List<Classifier>
@@ -54,7 +60,7 @@ abstract class ClassifierRepository implements ModelItemRepository<Classifier> {
     }
 
     @Nullable
-    abstract List<Classifier> findAll() 
+    abstract List<Classifier> findAll()
 
 
     @Nullable
@@ -109,5 +115,9 @@ abstract class ClassifierRepository implements ModelItemRepository<Classifier> {
         findAll()
     }
 
+
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        'cl'.equalsIgnoreCase(pathPrefix)
+    }
 }
 

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/classifier/dto/ClassificationSchemeDTORepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/classifier/dto/ClassificationSchemeDTORepository.groovy
@@ -3,6 +3,7 @@ package org.maurodata.persistence.classifier.dto
 import groovy.transform.CompileStatic
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.data.annotation.Join
+import io.micronaut.data.annotation.Query
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
 import io.micronaut.data.repository.GenericRepository
@@ -15,4 +16,8 @@ abstract class ClassificationSchemeDTORepository implements GenericRepository<Cl
     @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
     @Nullable
     abstract ClassificationSchemeDTO findById(UUID id)
+
+    @Nullable
+    @Query('select * from code.classification_scheme where folder_id = :item AND label = :pathIdentifier')
+    abstract List<ClassificationSchemeDTO> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier)
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/classifier/dto/ClassifierDTORepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/classifier/dto/ClassifierDTORepository.groovy
@@ -20,6 +20,11 @@ abstract class ClassifierDTORepository implements GenericRepository<ClassifierDT
     @Nullable
     abstract ClassifierDTO findById(UUID id)
 
+    @Nullable
+    @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
+    @Query('''select * from core.classifier where label = :pathIdentifier AND ((parent_classifier_id IS NOT NULL AND parent_classifier_id = :item) OR (parent_classifier_id IS NULL AND classification_scheme_id = :item))''')
+    abstract List<Classifier> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier)
+
     @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
     @Nullable
     abstract List<ClassifierDTO> findAllByClassificationScheme(ClassificationScheme classificationScheme)

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/config/ApiPropertyRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/config/ApiPropertyRepository.groovy
@@ -31,4 +31,9 @@ abstract class ApiPropertyRepository implements ItemRepository<ApiProperty> {
     @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
     @Join(value = 'lastUpdatedBy', type = Join.Type.LEFT_FETCH)
     abstract List<ApiProperty> findAll()
+
+    // Does not have a prefix
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        false
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/dataflow/DataClassComponentContentRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/dataflow/DataClassComponentContentRepository.groovy
@@ -45,4 +45,9 @@ class DataClassComponentContentRepository extends AdministeredItemContentReposit
         }
         dataClassComponentRepository.delete(administeredItem as DataClassComponent)
     }
+
+    @Override
+    Boolean handles(Class clazz) {
+        return clazz.simpleName == 'DataClassComponent'
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/dataflow/DataClassComponentRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/dataflow/DataClassComponentRepository.groovy
@@ -1,5 +1,7 @@
 package org.maurodata.persistence.dataflow
 
+import org.maurodata.persistence.dataflow.dto.DataClassComponentDTO
+
 import groovy.transform.CompileStatic
 import groovy.transform.MapConstructor
 import io.micronaut.core.annotation.NonNull
@@ -26,6 +28,11 @@ abstract class DataClassComponentRepository implements ModelItemRepository<DataC
     @Nullable
     DataClassComponent findById(UUID id) {
         dataClassComponentDTORepository.findById(id) as DataClassComponent
+    }
+
+    @Nullable
+    List<DataClassComponentDTO> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier) {
+        dataClassComponentDTORepository.findAllByParentAndPathIdentifier(item,pathIdentifier)
     }
 
     @Nullable
@@ -108,5 +115,9 @@ abstract class DataClassComponentRepository implements ModelItemRepository<DataC
     @Query(''' delete from dataflow.data_class_component_target_data_class t where t.data_class_component_id = :id ''')
     @Nullable
     abstract Long removeTargetDataClasses(@NonNull UUID id)
+
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        'dsc'.equalsIgnoreCase(pathPrefix)
+    }
 }
 

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/dataflow/DataElementComponentContentRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/dataflow/DataElementComponentContentRepository.groovy
@@ -43,4 +43,8 @@ class DataElementComponentContentRepository extends AdministeredItemContentRepos
         }
     }
 
+    @Override
+    Boolean handles(Class clazz) {
+        return clazz.simpleName == 'DataElementComponent'
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/dataflow/DataElementComponentRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/dataflow/DataElementComponentRepository.groovy
@@ -30,6 +30,11 @@ abstract class DataElementComponentRepository implements ModelItemRepository<Dat
     }
     @Override
     @Nullable
+    List<DataElementComponent> findAllByParentAndPathIdentifier(UUID item,String pathIdentifier) {
+        dataElementComponentDTORepository.findAllByParentAndPathIdentifier(item,pathIdentifier)
+    }
+    @Override
+    @Nullable
     List<DataElementComponent> findAllByParent(AdministeredItem dataClassComponent) {
         findAllByDataClassComponent((DataClassComponent) dataClassComponent) as List<DataElementComponent>
     }
@@ -90,4 +95,7 @@ abstract class DataElementComponentRepository implements ModelItemRepository<Dat
     @Query(''' delete from dataflow.data_element_component_target_data_element t where t.data_element_component_id = :id ''')
     abstract Long removeTargetDataElements(UUID id)
 
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        'dec'.equalsIgnoreCase(pathPrefix)
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/dataflow/DataFlowContentRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/dataflow/DataFlowContentRepository.groovy
@@ -32,4 +32,9 @@ class DataFlowContentRepository extends AdministeredItemContentRepository {
         }
         dataFlowRepository.delete(dataFlow)
     }
+
+    @Override
+    Boolean handles(Class clazz) {
+        return clazz.simpleName == 'DataFlow'
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/dataflow/DataFlowRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/dataflow/DataFlowRepository.groovy
@@ -34,6 +34,11 @@ abstract class DataFlowRepository implements ModelItemRepository<DataFlow> {
     }
 
     @Nullable
+    List<DataFlow> findAllByParentAndPathIdentifier(UUID item,String pathIdentifier) {
+        dataFlowDTORepository.findAllByParentAndPathIdentifier(item,pathIdentifier)
+    }
+
+    @Nullable
     List<DataFlow> findAllByTarget(DataModel dataModel) {
         dataFlowDTORepository.findAllByTarget(dataModel) as List<DataFlow>
     }
@@ -71,4 +76,7 @@ abstract class DataFlowRepository implements ModelItemRepository<DataFlow> {
        findById(id)
     }
 
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        'df'.equalsIgnoreCase(pathPrefix)
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/dataflow/dto/DataClassComponentDTORepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/dataflow/dto/DataClassComponentDTORepository.groovy
@@ -3,6 +3,7 @@ package org.maurodata.persistence.dataflow.dto
 import groovy.transform.CompileStatic
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.data.annotation.Join
+import io.micronaut.data.annotation.Query
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
 import io.micronaut.data.repository.GenericRepository
@@ -24,4 +25,12 @@ abstract class DataClassComponentDTORepository implements GenericRepository<Data
     @Join(value = 'targetDataClasses', type = Join.Type.LEFT_FETCH)
     @Nullable
     abstract List<DataClassComponentDTO> findAllByDataFlowId(UUID uuid)
+
+    @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
+    @Join(value = 'dataFlow', type = Join.Type.LEFT_FETCH)
+    @Join(value = 'sourceDataClasses', type = Join.Type.LEFT_FETCH)
+    @Join(value = 'targetDataClasses', type = Join.Type.LEFT_FETCH)
+    @Nullable
+    @Query('SELECT * FROM dataflow.data_class_component WHERE data_flow_id = :item AND label = :pathIdentifier')
+    abstract List<DataClassComponentDTO> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier)
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/dataflow/dto/DataElementComponentDTORepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/dataflow/dto/DataElementComponentDTORepository.groovy
@@ -1,10 +1,12 @@
 package org.maurodata.persistence.dataflow.dto
 
 import org.maurodata.domain.dataflow.DataClassComponent
+import org.maurodata.domain.dataflow.DataElementComponent
 
 import groovy.transform.CompileStatic
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.data.annotation.Join
+import io.micronaut.data.annotation.Query
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
 import io.micronaut.data.repository.GenericRepository
@@ -27,4 +29,12 @@ abstract class DataElementComponentDTORepository implements GenericRepository<Da
     @Join(value = 'targetDataElements', type = Join.Type.LEFT_FETCH)
     @Nullable
     abstract DataElementComponentDTO findById(UUID id)
-}
+
+    @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
+    @Join(value = 'dataClassComponent', type = Join.Type.LEFT_FETCH)
+    @Join(value = 'sourceDataElements', type = Join.Type.LEFT_FETCH)
+    @Join(value = 'targetDataElements', type = Join.Type.LEFT_FETCH)
+    @Nullable
+    @Query('SELECT * FROM dataflow.data_element_component WHERE data_class_component_id = :item AND label = :pathIdentifier')
+    abstract List<DataElementComponent> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier)
+    }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/dataflow/dto/DataFlowDTORepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/dataflow/dto/DataFlowDTORepository.groovy
@@ -1,8 +1,11 @@
 package org.maurodata.persistence.dataflow.dto
 
+import org.maurodata.domain.dataflow.DataFlow
+
 import groovy.transform.CompileStatic
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.data.annotation.Join
+import io.micronaut.data.annotation.Query
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
 import io.micronaut.data.repository.GenericRepository
@@ -27,4 +30,10 @@ abstract class DataFlowDTORepository implements GenericRepository<DataFlowDTO, U
     @Join(value = 'source', type = Join.Type.LEFT_FETCH)
     @Join(value = 'target', type = Join.Type.LEFT_FETCH)
     abstract List<DataFlowDTO> findAllBySource(DataModel source)
-}
+
+    @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
+    @Join(value = 'source', type = Join.Type.LEFT_FETCH)
+    @Join(value = 'target', type = Join.Type.LEFT_FETCH)
+    @Query('SELECT * FROM dataflow.data_flow WHERE target_id = :item AND label = :pathIdentifier')
+    abstract List<DataFlow> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier)
+    }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/DataClassContentRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/DataClassContentRepository.groovy
@@ -125,4 +125,9 @@ class DataClassContentRepository extends AdministeredItemContentRepository {
         }
         dataClass.dataElements
     }
+
+    @Override
+    Boolean handles(Class clazz) {
+        return clazz.simpleName == 'DataClass'
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/DataClassRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/DataClassRepository.groovy
@@ -31,6 +31,11 @@ abstract class DataClassRepository implements ModelItemRepository<DataClass> {
     }
 
     @Nullable
+    List<DataClass> findAllByParentAndPathIdentifier(UUID item,String pathIdentifier) {
+        dataClassDTORepository.findAllByParentAndPathIdentifier(item,pathIdentifier)
+    }
+
+    @Nullable
     List<DataClass> findAllByDataModel(DataModel dataModel) {
         dataClassDTORepository.findAllByDataModel(dataModel) as List<DataClass>
     }
@@ -98,5 +103,8 @@ abstract class DataClassRepository implements ModelItemRepository<DataClass> {
         domainClass.simpleName.equalsIgnoreCase(domainType) || (domainClass.simpleName + 'es').equalsIgnoreCase(domainType)
     }
 
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        'dc'.equalsIgnoreCase(pathPrefix)
+    }
 }
 

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/DataElementContentRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/DataElementContentRepository.groovy
@@ -20,4 +20,9 @@ class DataElementContentRepository extends AdministeredItemContentRepository {
         DataElement dataElement = dataElementCacheableRepository.readById(id)
         dataElement
     }
+
+    @Override
+    Boolean handles(Class clazz) {
+        return clazz.simpleName == 'DataElement'
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/DataElementRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/DataElementRepository.groovy
@@ -32,6 +32,11 @@ abstract class DataElementRepository implements  ModelItemRepository<DataElement
     }
 
     @Nullable
+    List<DataElement> findAllByParentAndPathIdentifier(UUID item,String pathIdentifier) {
+        dataElementDTORepository.findAllByParentAndPathIdentifier(item,pathIdentifier)
+    }
+
+    @Nullable
     List<DataElement> findAllByDataClass(DataClass dataClass) {
         dataElementDTORepository.findAllByDataClass(dataClass) as List<DataElement>
     }
@@ -81,5 +86,9 @@ abstract class DataElementRepository implements  ModelItemRepository<DataElement
     }
 
     abstract List<DataElement> readAllByDataClassId(UUID dataClassId)
+
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        'de'.equalsIgnoreCase(pathPrefix)
+    }
 
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/DataModelRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/DataModelRepository.groovy
@@ -24,6 +24,11 @@ abstract class DataModelRepository implements ModelRepository<DataModel> {
         dataModelDTORepository.findById(id) as DataModel
     }
 
+    @Nullable
+    List<DataModel> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier) {
+        dataModelDTORepository.findAllByParentAndPathIdentifier(item, pathIdentifier)
+    }
+
     @Override
     Class getDomainClass() {
         DataModel
@@ -49,4 +54,7 @@ abstract class DataModelRepository implements ModelRepository<DataModel> {
         return domainType != null && domainType.toLowerCase() in [FieldConstants.DATAMODEL_LOWERCASE, FieldConstants.DATAMODELS_LOWERCASE]
     }
 
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        'dm'.equalsIgnoreCase(pathPrefix)
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/DataTypeContentRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/DataTypeContentRepository.groovy
@@ -45,4 +45,9 @@ class DataTypeContentRepository extends AdministeredItemContentRepository {
 
         dataTypes
     }
+
+    @Override
+    Boolean handles(Class clazz) {
+        return clazz.simpleName == 'DataType'
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/DataTypeRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/DataTypeRepository.groovy
@@ -16,6 +16,11 @@ abstract class DataTypeRepository implements ModelItemRepository<DataType> {
     @Inject
     DataTypeDTORepository dataTypeDTORepository
 
+    @Nullable
+    List<DataType> findAllByParentAndPathIdentifier(UUID item,String pathIdentifier) {
+        dataTypeDTORepository.findAllByParentAndPathIdentifier(item,pathIdentifier)
+    }
+
     @Override
     @Nullable
     DataType findById(UUID id) {
@@ -72,4 +77,7 @@ abstract class DataTypeRepository implements ModelItemRepository<DataType> {
                 'modeldatatypes']
     }
 
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        'dt'.equalsIgnoreCase(pathPrefix)
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/EnumerationValueContentRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/EnumerationValueContentRepository.groovy
@@ -24,4 +24,9 @@ class EnumerationValueContentRepository extends AdministeredItemContentRepositor
 
         enumerationValue
     }
+
+    @Override
+    Boolean handles(Class clazz) {
+        return clazz.simpleName == 'EnumerationValue'
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/EnumerationValueRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/EnumerationValueRepository.groovy
@@ -28,6 +28,11 @@ abstract class EnumerationValueRepository implements ModelItemRepository<Enumera
     }
 
     @Nullable
+    List<EnumerationValue> findAllByParentAndPathIdentifier(UUID item,String pathIdentifier) {
+        enumerationValueDTORepository.findAllByParentAndPathIdentifier(item,pathIdentifier)
+    }
+
+    @Nullable
     List<EnumerationValue> findAllByEnumerationType(DataType dataType) {
         enumerationValueDTORepository.findAllByEnumerationType(dataType) as List<EnumerationValue>
     }
@@ -69,5 +74,7 @@ abstract class EnumerationValueRepository implements ModelItemRepository<Enumera
 
     abstract List<EnumerationValue> readAllByEnumerationTypeId(UUID enumerationTypeId)
 
-
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        'ev'.equalsIgnoreCase(pathPrefix)
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/dto/DataClassDTORepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/dto/DataClassDTORepository.groovy
@@ -3,6 +3,7 @@ package org.maurodata.persistence.datamodel.dto
 import groovy.transform.CompileStatic
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.data.annotation.Join
+import io.micronaut.data.annotation.Query
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
 import io.micronaut.data.repository.GenericRepository
@@ -25,4 +26,7 @@ abstract class DataClassDTORepository implements GenericRepository<DataClassDTO,
     @Nullable
     abstract List<DataClassDTO> findAllByParentDataClass(DataClass parentDataClass)
 
-}
+    @Nullable
+    @Query('SELECT * FROM datamodel.data_class WHERE label = :pathIdentifier AND ((parent_data_class_id IS NOT NULL AND parent_data_class_id = :item) OR (parent_data_class_id IS NULL AND data_model_id = :item))')
+    abstract List<DataClass> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier)
+    }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/dto/DataElementDTORepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/dto/DataElementDTORepository.groovy
@@ -1,9 +1,11 @@
 package org.maurodata.persistence.datamodel.dto
 
+import org.maurodata.domain.datamodel.DataElement
 import org.maurodata.domain.datamodel.DataType
 
 import groovy.transform.CompileStatic
 import io.micronaut.data.annotation.Join
+import io.micronaut.data.annotation.Query
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
 import io.micronaut.data.repository.GenericRepository
@@ -22,4 +24,6 @@ abstract class DataElementDTORepository implements GenericRepository<DataElement
 
     abstract List<DataElementDTO> readAllByDataTypeIdIn(Collection<UUID> ids)
 
+    @Query('SELECT * FROM datamodel.data_element WHERE data_class_id = :item AND label = :pathIdentifier')
+    abstract List<DataElement> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier)
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/dto/DataModelDTORepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/dto/DataModelDTORepository.groovy
@@ -1,8 +1,11 @@
 package org.maurodata.persistence.datamodel.dto
 
+import org.maurodata.domain.datamodel.DataModel
+
 import groovy.transform.CompileStatic
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.data.annotation.Join
+import io.micronaut.data.annotation.Query
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
 import io.micronaut.data.repository.GenericRepository
@@ -15,4 +18,10 @@ abstract class DataModelDTORepository implements GenericRepository<DataModelDTO,
     @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
     @Nullable
     abstract DataModelDTO findById(UUID id)
+
+    @Join(value = 'authority', type = Join.Type.LEFT_FETCH)
+    @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
+    @Nullable
+    @Query('SELECT * FROM datamodel.data_model WHERE folder_id = :item AND label = :pathIdentifier')
+    abstract List<DataModel> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier)
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/dto/DataTypeDTORepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/dto/DataTypeDTORepository.groovy
@@ -1,8 +1,11 @@
 package org.maurodata.persistence.datamodel.dto
 
+import org.maurodata.domain.datamodel.DataType
+
 import groovy.transform.CompileStatic
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.data.annotation.Join
+import io.micronaut.data.annotation.Query
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
 import io.micronaut.data.repository.GenericRepository
@@ -31,4 +34,8 @@ abstract class DataTypeDTORepository implements GenericRepository<DataTypeDTO, U
     @Nullable
     @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
     abstract List<DataTypeDTO> findByReferenceClassIdIn(List<UUID> referenceClassIds)
+
+    @Nullable
+    @Query('SELECT * FROM datamodel.data_type WHERE label = :pathIdentifier AND data_model_id = :item')
+    abstract List<DataType> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier)
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/dto/EnumerationValueDTORepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/dto/EnumerationValueDTORepository.groovy
@@ -1,8 +1,11 @@
 package org.maurodata.persistence.datamodel.dto
 
+import org.maurodata.domain.datamodel.EnumerationValue
+
 import groovy.transform.CompileStatic
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.data.annotation.Join
+import io.micronaut.data.annotation.Query
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
 import io.micronaut.data.repository.GenericRepository
@@ -23,4 +26,9 @@ abstract class EnumerationValueDTORepository implements GenericRepository<Enumer
     @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
     @Nullable
     abstract Set<EnumerationValueDTO> findAllByEnumerationTypeIn(Collection<DataType> dataTypes)
+
+    @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
+    @Nullable
+    @Query('SELECT * FROM datamodel.enumeration_value WHERE enumeration_type_id = :item AND label = :pathIdentifier')
+    abstract List<EnumerationValue> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier)
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/facet/AnnotationRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/facet/AnnotationRepository.groovy
@@ -22,4 +22,8 @@ abstract class AnnotationRepository implements ItemRepository<Annotation> {
     Class getDomainClass() {
         Annotation
     }
+
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        'ann'.equalsIgnoreCase(pathPrefix)
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/facet/EditRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/facet/EditRepository.groovy
@@ -16,4 +16,8 @@ abstract class EditRepository implements ItemRepository<Edit> {
         Edit
     }
 
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        'ed'.equalsIgnoreCase(pathPrefix)
+    }
+
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/facet/MetadataRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/facet/MetadataRepository.groovy
@@ -27,5 +27,7 @@ abstract class MetadataRepository implements ItemRepository<Metadata> {
             [key, values.collect {it.key} as Set]
         }
     }
-
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        'md'.equalsIgnoreCase(pathPrefix)
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/facet/ReferenceFileRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/facet/ReferenceFileRepository.groovy
@@ -18,4 +18,7 @@ abstract class ReferenceFileRepository implements ItemRepository<ReferenceFile> 
     Class getDomainClass() {
         ReferenceFile
     }
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        'rf'.equalsIgnoreCase(pathPrefix)
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/facet/RuleRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/facet/RuleRepository.groovy
@@ -15,4 +15,8 @@ abstract class RuleRepository implements ItemRepository<Rule> {
     Class getDomainClass() {
         Rule
     }
+
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        'ru'.equalsIgnoreCase(pathPrefix)
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/facet/RuleRepresentationRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/facet/RuleRepresentationRepository.groovy
@@ -23,4 +23,8 @@ abstract class RuleRepresentationRepository implements ItemRepository<RuleRepres
     Class getDomainClass() {
         RuleRepresentation
     }
+
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        'rr'.equalsIgnoreCase(pathPrefix)
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/facet/SemanticLinkRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/facet/SemanticLinkRepository.groovy
@@ -15,5 +15,7 @@ abstract class SemanticLinkRepository implements ItemRepository<SemanticLink> {
     Class getDomainClass() {
         SemanticLink
     }
-
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        'sl'.equalsIgnoreCase(pathPrefix)
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/facet/SummaryMetadataReportRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/facet/SummaryMetadataReportRepository.groovy
@@ -23,4 +23,8 @@ abstract class SummaryMetadataReportRepository implements ItemRepository<Summary
     Class getDomainClass() {
         SummaryMetadataReport
     }
+
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        'smr'.equalsIgnoreCase(pathPrefix)
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/facet/SummaryMetadataRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/facet/SummaryMetadataRepository.groovy
@@ -14,4 +14,7 @@ abstract class SummaryMetadataRepository implements ItemRepository<SummaryMetada
     Class getDomainClass() {
         SummaryMetadata
     }
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        'sm'.equalsIgnoreCase(pathPrefix)
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/facet/VersionLinkRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/facet/VersionLinkRepository.groovy
@@ -22,5 +22,8 @@ abstract class VersionLinkRepository implements ItemRepository<VersionLink>{
     Class getDomainClass() {
         VersionLink
     }
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        'vl'.equalsIgnoreCase(pathPrefix)
+    }
 }
 

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/federation/SubscribedCatalogueRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/federation/SubscribedCatalogueRepository.groovy
@@ -25,4 +25,8 @@ abstract class SubscribedCatalogueRepository implements ItemRepository<Subscribe
         SubscribedCatalogue
     }
 
+    // Not currently pathable
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        false
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/federation/SubscribedModelRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/federation/SubscribedModelRepository.groovy
@@ -33,4 +33,9 @@ abstract class SubscribedModelRepository implements ItemRepository<SubscribedMod
     Class getDomainClass() {
         SubscribedModel
     }
+
+    // Not currently pathable
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        false
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/folder/FolderRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/folder/FolderRepository.groovy
@@ -23,6 +23,11 @@ abstract class FolderRepository implements ModelRepository<Folder> {
     }
 
     @Nullable
+    List<Folder> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier) {
+        folderDTORepository.findAllByParentAndPathIdentifier(item, pathIdentifier)
+    }
+
+    @Nullable
     abstract List<Folder> readAllByParentFolder(Folder folder)
 
     @Nullable
@@ -53,5 +58,9 @@ abstract class FolderRepository implements ModelRepository<Folder> {
     @Override
     Boolean handles(String domainType) {
         return domainType != null && domainType.toLowerCase() in ['folder', 'folders', 'versionedfolder', 'versionedfolders']
+    }
+
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        'fo'.equalsIgnoreCase(pathPrefix) || 'vf'.equalsIgnoreCase(pathPrefix)
     }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/folder/dto/FolderDTORepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/folder/dto/FolderDTORepository.groovy
@@ -1,8 +1,11 @@
 package org.maurodata.persistence.folder.dto
 
+import org.maurodata.domain.folder.Folder
+
 import groovy.transform.CompileStatic
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.data.annotation.Join
+import io.micronaut.data.annotation.Query
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
 import io.micronaut.data.repository.GenericRepository
@@ -16,4 +19,11 @@ abstract class FolderDTORepository implements GenericRepository<FolderDTO, UUID>
     @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
     @Nullable
     abstract FolderDTO findById(UUID id)
+
+    @Join(value = 'authority', type = Join.Type.LEFT_FETCH)
+    @Join(value = 'childFolders', type = Join.Type.LEFT_FETCH)
+    @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
+    @Nullable
+    @Query('SELECT * FROM core.folder WHERE parent_folder_id = :item AND label = :pathIdentifier')
+    abstract List<Folder> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier)
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/model/AdministeredItemContentRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/model/AdministeredItemContentRepository.groovy
@@ -316,6 +316,8 @@ class AdministeredItemContentRepository {
         it.multiFacetAwareItem = item
     }
 
-
+    Boolean handles(Class clazz) {
+        return false
+    }
 }
 

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/model/AdministeredItemRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/model/AdministeredItemRepository.groovy
@@ -15,4 +15,9 @@ trait AdministeredItemRepository<I extends AdministeredItem> implements ItemRepo
 
     @Nullable
     abstract List<I> readAllByParent(AdministeredItem item)
+
+    @Nullable
+    List<I> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier){
+        throw new UnsupportedOperationException('Method should be implemented')
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/model/ItemRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/model/ItemRepository.groovy
@@ -43,4 +43,6 @@ trait ItemRepository<I extends Item> implements GenericRepository<I, UUID> {
     }
 
     abstract List<I> readAll()
+
+    abstract Boolean handlesPathPrefix(final String pathPrefix)
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/model/ModelContentRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/model/ModelContentRepository.groovy
@@ -156,8 +156,8 @@ class ModelContentRepository<M extends Model> extends AdministeredItemContentRep
     void saveVersionLinks(List<AdministeredItem> items) {
         List<VersionLink> versionLinks = []
         items.each {item ->
-            if(item instanceof Model) {
-                final Model modelItem=(Model) item
+            if (item instanceof Model) {
+                final Model modelItem = (Model) item
                 if (modelItem.versionLinks) {
                     modelItem.versionLinks.each {
                         updateMultiAwareData(item, it)
@@ -166,7 +166,11 @@ class ModelContentRepository<M extends Model> extends AdministeredItemContentRep
                 }
             }
         }
-        versionLinkCacheableRepository.saveAll(versionLinks)
+        versionLinks.each {
+            if (it.id == null || !versionLinkCacheableRepository.existsById(it.id)) {
+                versionLinkCacheableRepository.save(it)
+            }
+        }
     }
 
     void saveSemanticLinks(List<AdministeredItem> items) {
@@ -194,5 +198,10 @@ class ModelContentRepository<M extends Model> extends AdministeredItemContentRep
 
     Boolean handles(String domainType) {
         administeredItemRepository.handles(domainType)
+    }
+
+    @Override
+    Boolean handles(Class clazz) {
+        Model.isAssignableFrom(clazz) && clazz != Model
     }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/model/PathRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/model/PathRepository.groovy
@@ -1,6 +1,7 @@
 package org.maurodata.persistence.model
 
 import org.maurodata.domain.model.AdministeredItem
+import org.maurodata.domain.model.ItemReference
 import org.maurodata.domain.model.Path
 import org.maurodata.exception.MauroInternalException
 import org.maurodata.persistence.cache.AdministeredItemCacheableRepository
@@ -40,5 +41,56 @@ class PathRepository {
     @NonNull
     AdministeredItemRepository getRepository(AdministeredItem item) {
         cacheableRepositories.find {it.handles(item.class) || it.handles(item.domainType)} ?: administeredItemRepositories.find {it.handles(item.class) || it.handles(item.domainType)}
+    }
+
+    @NonNull
+    AdministeredItemRepository getRepositoryForPathPrefix(final String prefix) {
+        cacheableRepositories.find {it.handlesPathPrefix(prefix)} ?: administeredItemRepositories.find {it.handlesPathPrefix(prefix)}
+    }
+
+    @NonNull
+    AdministeredItemRepository getRepositoryForDomainType(final String domainType) {
+        cacheableRepositories.find {it.handles(domainType)} ?: administeredItemRepositories.find {it.handles(domainType)}
+    }
+
+    AdministeredItem findResourcesByPathFromRootResource(final AdministeredItem resource, final Path path) {
+        findResourcesByPathFromRootResource(resource, path, 1)
+    }
+
+    protected AdministeredItem findResourcesByPathFromRootResource(final AdministeredItem resource, final Path path, final int positionInPath) {
+
+        if (positionInPath >= path.nodes.size()) {
+            readParentItems(resource)
+            resource.updatePath()
+            return resource
+        }
+        final Path.PathNode currentNode = path.nodes.get(positionInPath)
+        final AdministeredItemRepository prefixRepository = getRepositoryForPathPrefix(currentNode.prefix)
+        if (prefixRepository == null) {throw new MauroInternalException("No repository claims to handle the prefix " + currentNode.prefix)}
+        final List<AdministeredItem> children = prefixRepository.findAllByParentAndPathIdentifier(resource.id, currentNode.identifier)
+        if (children.size() > 1) {throw new MauroInternalException("More than one Item returned for " + currentNode.prefix + " " + currentNode.identifier)}
+        if (children.size() == 0) {
+            return null
+        }
+        final AdministeredItem currentAdministeredItem = (AdministeredItem) children.get(0)
+        return findResourcesByPathFromRootResource(currentAdministeredItem, path, positionInPath + 1)
+    }
+
+    List<Path> resolveItemReferences(final List<ItemReference> itemReferences) {
+        final List<Path> resolved = []
+        itemReferences.forEach {ItemReference itemReference ->
+
+            if (itemReference.pathToItem != null) {
+                resolved << itemReference.pathToItem
+            } else {
+                final AdministeredItemRepository administeredItemRepository = getRepositoryForDomainType(itemReference.itemDomainType)
+                final AdministeredItem resolvedAdministeredItem = (AdministeredItem) administeredItemRepository.findById(itemReference.itemId)
+                if (resolvedAdministeredItem == null) {throw new MauroInternalException("Did not find reference to " + itemReference.toString())}
+                readParentItems(resolvedAdministeredItem)
+                resolvedAdministeredItem.updatePath()
+                resolved << resolvedAdministeredItem.getPathToEdge()
+            }
+        }
+        return resolved
     }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/security/ApiKeyRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/security/ApiKeyRepository.groovy
@@ -24,4 +24,8 @@ abstract class ApiKeyRepository implements ItemRepository<ApiKey> {
         ApiKey
     }
 
+    // Not currently pathable
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        false
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/security/CatalogueUserRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/security/CatalogueUserRepository.groovy
@@ -18,4 +18,9 @@ abstract class CatalogueUserRepository implements ItemRepository<CatalogueUser> 
     Class getDomainClass() {
         CatalogueUser
     }
+
+    // Not pathable
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        false
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/security/SecurableResourceGroupRoleRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/security/SecurableResourceGroupRoleRepository.groovy
@@ -19,4 +19,9 @@ abstract class SecurableResourceGroupRoleRepository implements ItemRepository<Se
     Class getDomainClass() {
         SecurableResourceGroupRole
     }
+
+    // Not pathable
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        false
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/security/UserGroupRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/security/UserGroupRepository.groovy
@@ -22,4 +22,9 @@ abstract class UserGroupRepository implements ItemRepository<UserGroup> {
     Class getDomainClass() {
         UserGroup
     }
+
+    // Not pathable
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        false
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/service/TreeService.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/service/TreeService.groovy
@@ -156,6 +156,9 @@ class TreeService {
         List<TreeItem> treeItems = dataClassCacheableRepository.readAllByDataModelAndParentDataClassIsNull(dataModel)
             .sort {it.label}
             .collect {DataClass dataClass ->
+                pathRepository.readParentItems(dataClass)
+                dataClass.updatePath()
+                dataClass.updateBreadcrumbs()
                 TreeItem.from(dataClass).tap {
                     model = dataClass.dataModel
                     List<TreeItem> theChildren
@@ -173,6 +176,9 @@ class TreeService {
 
     List<TreeItem> buildTreeForDataClass(DataClass dataClass, boolean setChildren, boolean lookForChildren) {
         dataClassCacheableRepository.readAllByParentDataClass_Id(dataClass.id).sort {it.label}.collect {DataClass childClass ->
+            pathRepository.readParentItems(dataClass)
+            dataClass.updatePath()
+            dataClass.updateBreadcrumbs()
             TreeItem.from(childClass).tap {
                 model = childClass.dataModel
 
@@ -190,6 +196,9 @@ class TreeService {
 
     List<TreeItem> buildTreeForTerminology(Terminology terminology, boolean setChildren, boolean lookForChildren) {
         termCacheableRepository.readChildTermsByParent(terminology.id, null).sort {it.code}.collect {Term term ->
+            pathRepository.readParentItems(term)
+            term.updatePath()
+            term.updateBreadcrumbs()
             TreeItem.from(term).tap {
                 model = term.terminology
 
@@ -207,6 +216,9 @@ class TreeService {
 
     List<TreeItem> buildTreeForTerm(Term term, boolean setChildren, boolean lookForChildren) {
         termCacheableRepository.readChildTermsByParent(term.terminology.id, term.id).sort {it.code}.collect {Term childTerm ->
+            pathRepository.readParentItems(childTerm)
+            childTerm.updatePath()
+            childTerm.updateBreadcrumbs()
             TreeItem.from(childTerm).tap {
                 model = childTerm.terminology
                 List<TreeItem> theChildren
@@ -224,6 +236,9 @@ class TreeService {
     List<TreeItem> buildTreeForClassificationScheme(ClassificationScheme classificationScheme, boolean setChildren, boolean lookForChildren) {
         List<TreeItem> treeItems =
             classifierCacheableRepository.readAllByClassificationScheme_Id(classificationScheme.id).sort {it.label}.collect {Classifier childClassifier ->
+                pathRepository.readParentItems(childClassifier)
+                childClassifier.updatePath()
+                childClassifier.updateBreadcrumbs()
                 TreeItem.from(childClassifier).tap {
                     model = childClassifier.classificationScheme
                     List<TreeItem> theChildren
@@ -241,6 +256,9 @@ class TreeService {
 
     List<TreeItem> buildTreeForClassifier(Classifier classifier, boolean setChildren, boolean lookForChildren) {
         classifierCacheableRepository.readAllByParentClassifier_Id(classifier.id).sort {it.label}.collect {Classifier child ->
+            pathRepository.readParentItems(child)
+            child.updatePath()
+            child.updateBreadcrumbs()
             TreeItem.from(child).tap {
                 model = child.classificationScheme
                 List<TreeItem> theChildren

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/CodeSetRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/CodeSetRepository.groovy
@@ -25,6 +25,11 @@ abstract class CodeSetRepository implements ModelRepository<CodeSet> {
         codeSetDTORepository.findById(id) as CodeSet
     }
 
+    @Nullable
+    List<CodeSet> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier) {
+        codeSetDTORepository.findAllByParentAndPathIdentifier(item, pathIdentifier)
+    }
+
     /**
      * Remove all associations from table code_set_terms
      * @param id codeSetId
@@ -66,5 +71,9 @@ abstract class CodeSetRepository implements ModelRepository<CodeSet> {
     @Override
     Boolean handles(String domainType) {
         return domainType != null && domainType.toLowerCase() in [FieldConstants.CODESET_LOWERCASE, FieldConstants.CODESETS_LOWERCASE]
+    }
+
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        'cs'.equalsIgnoreCase(pathPrefix)
     }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/TermContentRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/TermContentRepository.groovy
@@ -25,4 +25,9 @@ class TermContentRepository extends AdministeredItemContentRepository {
         term.targetTermRelationships = termRelationshipCacheableRepository.readAllByTargetTerm(term)
         term
     }
+
+    @Override
+    Boolean handles(Class clazz) {
+        return clazz.simpleName == 'Term'
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/TermRelationshipRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/TermRelationshipRepository.groovy
@@ -35,6 +35,11 @@ abstract class TermRelationshipRepository implements ModelItemRepository<TermRel
     }
 
     @Nullable
+    List<TermRelationship> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier) {
+        termRelationshipDTORepository.findAllByParentAndPathIdentifier(item, pathIdentifier)
+    }
+
+    @Nullable
     List<TermRelationship> findAllByTerminology(Terminology terminology) {
         termRelationshipDTORepository.findAllByTerminology(terminology) as List<TermRelationship>
     }
@@ -74,5 +79,9 @@ abstract class TermRelationshipRepository implements ModelItemRepository<TermRel
     @Override
     Class getDomainClass() {
         TermRelationship
+    }
+
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        'tr'.equalsIgnoreCase(pathPrefix)
     }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/TermRelationshipTypeContentRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/TermRelationshipTypeContentRepository.groovy
@@ -24,4 +24,9 @@ class TermRelationshipTypeContentRepository extends AdministeredItemContentRepos
         relationshipType.termRelationships = termRelationshipCacheableRepository.readAllByRelationshipType(relationshipType)
         relationshipType
     }
+
+    @Override
+    Boolean handles(Class clazz) {
+        return clazz.simpleName == 'TermRelationshipType'
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/TermRelationshipTypeRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/TermRelationshipTypeRepository.groovy
@@ -25,6 +25,11 @@ abstract class TermRelationshipTypeRepository implements ModelItemRepository<Ter
     }
 
     @Nullable
+    List<TermRelationshipType> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier) {
+        termRelationshipTypeDTORepository.findAllByParentAndPathIdentifier(item, pathIdentifier)
+    }
+
+    @Nullable
     List<TermRelationshipType> findAllByTerminology(Terminology terminology) {
         termRelationshipTypeDTORepository.findAllByTerminology(terminology) as List<TermRelationshipType>
     }
@@ -56,5 +61,9 @@ abstract class TermRelationshipTypeRepository implements ModelItemRepository<Ter
     @Override
     Class getDomainClass() {
         TermRelationshipType
+    }
+
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        'trt'.equalsIgnoreCase(pathPrefix)
     }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/TermRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/TermRepository.groovy
@@ -32,6 +32,11 @@ abstract class TermRepository implements ModelItemRepository<Term> {
     }
 
     @Nullable
+    List<Term> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier) {
+        termDTORepository.findAllByParentAndPathIdentifier(item, pathIdentifier)
+    }
+
+    @Nullable
     List<Term> findAllByTerminology(Terminology terminology) {
         termDTORepository.findAllByTerminology(terminology) as List<Term>
     }
@@ -78,5 +83,9 @@ abstract class TermRepository implements ModelItemRepository<Term> {
     @Override
     Class getDomainClass() {
         Term
+    }
+
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        'tm'.equalsIgnoreCase(pathPrefix)
     }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/TerminologyRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/TerminologyRepository.groovy
@@ -24,6 +24,11 @@ abstract class TerminologyRepository implements ModelRepository<Terminology> {
         terminologyDTORepository.findById(id)
     }
 
+    @Nullable
+    List<Terminology> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier) {
+        terminologyDTORepository.findAllByParentAndPathIdentifier(item, pathIdentifier)
+    }
+
     @Override
     Class getDomainClass() {
         Terminology
@@ -36,5 +41,9 @@ abstract class TerminologyRepository implements ModelRepository<Terminology> {
     @Override
     Boolean handles(String domainType) {
         return domainType != null && domainType.toLowerCase() in [FieldConstants.TERMINOLOGY_LOWERCASE, FieldConstants.TERMINOLOGIES_LOWERCASE]
+    }
+
+    Boolean handlesPathPrefix(final String pathPrefix) {
+        'te'.equalsIgnoreCase(pathPrefix)
     }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/dto/CodeSetDTORepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/dto/CodeSetDTORepository.groovy
@@ -1,7 +1,9 @@
 package org.maurodata.persistence.terminology.dto
 
+import org.maurodata.domain.terminology.CodeSet
 import groovy.transform.CompileStatic
 import io.micronaut.data.annotation.Join
+import io.micronaut.data.annotation.Query
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
 import io.micronaut.data.repository.GenericRepository
@@ -13,5 +15,7 @@ abstract class CodeSetDTORepository implements GenericRepository<CodeSetDTO, UUI
     @Join(value = 'authority', type = Join.Type.LEFT_FETCH)
     abstract CodeSetDTO findById(UUID id)
 
-
+    @Join(value = 'authority', type = Join.Type.LEFT_FETCH)
+    @Query('SELECT * FROM terminology.code_set WHERE folder_id = :item AND label = :pathIdentifier')
+    abstract List<CodeSet> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier)
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/dto/TermDTORepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/dto/TermDTORepository.groovy
@@ -1,8 +1,11 @@
 package org.maurodata.persistence.terminology.dto
 
+import org.maurodata.domain.terminology.Term
+
 import groovy.transform.CompileStatic
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.data.annotation.Join
+import io.micronaut.data.annotation.Query
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
 import io.micronaut.data.repository.GenericRepository
@@ -19,4 +22,9 @@ abstract class TermDTORepository implements GenericRepository<TermDTO, UUID> {
     @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
     @Nullable
     abstract List<TermDTO> findAllByTerminology(Terminology terminology)
+
+    @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
+    @Nullable
+    @Query('SELECT * FROM terminology.term WHERE terminology_id = :item AND label = :pathIdentifier')
+    abstract List<Term> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier)
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/dto/TermRelationshipDTORepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/dto/TermRelationshipDTORepository.groovy
@@ -1,8 +1,11 @@
 package org.maurodata.persistence.terminology.dto
 
+import org.maurodata.domain.terminology.TermRelationship
+
 import groovy.transform.CompileStatic
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.data.annotation.Join
+import io.micronaut.data.annotation.Query
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
 import io.micronaut.data.repository.GenericRepository
@@ -33,4 +36,12 @@ abstract class TermRelationshipDTORepository implements GenericRepository<TermRe
     @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
     @Nullable
     abstract List<TermRelationshipDTO> findAllByTerminologyAndSourceTermOrTargetTerm(Terminology terminology, Term sourceTerm, Term targetTerm)
+
+    @Join(value = 'sourceTerm', type = Join.Type.LEFT_FETCH)
+    @Join(value = 'targetTerm', type = Join.Type.LEFT_FETCH)
+    @Join(value = 'relationshipType', type = Join.Type.LEFT_FETCH)
+    @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
+    @Nullable
+    @Query('SELECT * FROM terminology.term_relationship WHERE target_term_id = :item AND label = :pathIdentifier')
+    abstract List<TermRelationship> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier)
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/dto/TermRelationshipTypeDTORepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/dto/TermRelationshipTypeDTORepository.groovy
@@ -1,8 +1,11 @@
 package org.maurodata.persistence.terminology.dto
 
+import org.maurodata.domain.terminology.TermRelationshipType
+
 import groovy.transform.CompileStatic
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.data.annotation.Join
+import io.micronaut.data.annotation.Query
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
 import io.micronaut.data.repository.GenericRepository
@@ -19,4 +22,9 @@ abstract class TermRelationshipTypeDTORepository implements GenericRepository<Te
     @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
     @Nullable
     abstract List<TermRelationshipTypeDTO> findAllByTerminology(Terminology terminology)
+
+    @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
+    @Nullable
+    @Query('SELECT * FROM terminology.term_relationship_type WHERE terminology_id = :item AND label = :pathIdentifier')
+    abstract List<TermRelationshipType> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier)
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/dto/TerminologyDTORepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/dto/TerminologyDTORepository.groovy
@@ -1,8 +1,11 @@
 package org.maurodata.persistence.terminology.dto
 
+import org.maurodata.domain.terminology.Terminology
+
 import groovy.transform.CompileStatic
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.data.annotation.Join
+import io.micronaut.data.annotation.Query
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
 import io.micronaut.data.repository.GenericRepository
@@ -15,4 +18,10 @@ abstract class TerminologyDTORepository implements GenericRepository<Terminology
     @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
     @Nullable
     abstract TerminologyDTO findById(UUID id)
+
+    @Join(value = 'authority', type = Join.Type.LEFT_FETCH)
+    @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
+    @Nullable
+    @Query('SELECT * FROM terminology.terminology WHERE folder_id = :item AND label = :pathIdentifier')
+    abstract List<Terminology> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier)
 }


### PR DESCRIPTION
Get Inject functioning
DeleteAction
If a merge would cause a deletion in the target, give the user a choice by offering the change as a conflict
HttpException if deleting a DataClass that is referenced by a DataType
merge delete, merge update
Tests run: use of diffIdentifier by ObjectDiff, cloning tests use equatable comparisons (e.g. hashCode() and id)
simpleModelVersionTree: branchesOnly flag
Rejigged Model.getModelWithVersion() and Model/Folder .getBranchName()
TreeController / Tree Service gets item path and breadcrumbs
Implemented ItemReferencer for CodeSet, DataClass, SemanticLink, and VersionLink
Fixed Map lookup in DataModel.clone() to use UUID as reliable hash value
Missing details for simpleModelVersionTree
Plugged in CodeSet simpleModelVersionTree
Introduced ItemReference, ItemReferencer
PathRepository resolves List<ItemReference> to List<Path>
Path.findNodeItem used to detect whether Item is part of a particular Model
DataType implements ItemReferencer
ModelController.processModificationPatchIntoModel clones referenced items returned by an ItemReferencer and calls replaceItemReferences to replace with cloned items
Creation patch also creates parent path if not exists
Diff identifier paths in Facets and AdministeredItem
Repositories understand prefixes
Added all prefixes that are in Grails
Implemented findAllByParentAndPathIdentifier
diffIdentifer into BaseCollectionDiff
Added Pathable
Facets are Pathable
Connected all of the getDiffIdentifier()
MergeInto
Refactored from DataModelController, VersionedFolderController into ModelController
Added AdministeredItem.getPathNodeString
Ignore pathNodeString and diffIdentifier when Diffing
Edit.createEntity and createEdit
CHANGENOTICE EditType
Path getParent() getItem() trimUntil()
PathRepository getRepositoryForPrefix() and findResourcesByPathFromRootResource() to be able to follow paths through a model
Refactor mergeDiff
Add DTOs and Paths for mergeInto
