### PR TITLE
delete folders -include classificationscheme model; tidy code

### DIFF
--- a/mauro-api/src/main/groovy/org/maurodata/controller/model/AdministeredItemController.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/controller/model/AdministeredItemController.groovy
@@ -80,9 +80,6 @@ abstract class AdministeredItemController<I extends AdministeredItem, P extends 
     protected P validate(I item, UUID parentId) {
         cleanBody(item)
         P parent = parentItemRepository.readById(parentId)
-        if (!parent){
-            ErrorHandler.handleError(HttpStatus.UNPROCESSABLE_ENTITY, 'Parent is null')
-        }
         accessControlService.checkRole(Role.EDITOR, parent)
         parent
     }

--- a/mauro-api/src/test/groovy/org/maurodata/dataflow/DataFlowIntegrationSpec.groovy
+++ b/mauro-api/src/test/groovy/org/maurodata/dataflow/DataFlowIntegrationSpec.groovy
@@ -87,7 +87,7 @@ class DataFlowIntegrationSpec extends CommonDataSpec {
 
         then:
         HttpClientResponseException exception = thrown()
-        exception.status == HttpStatus.UNPROCESSABLE_ENTITY
+        exception.status == HttpStatus.BAD_REQUEST
     }
 
 

--- a/mauro-api/src/test/groovy/org/maurodata/folder/DeleteFolderIntegrationSpec.groovy
+++ b/mauro-api/src/test/groovy/org/maurodata/folder/DeleteFolderIntegrationSpec.groovy
@@ -5,6 +5,8 @@ import io.micronaut.http.HttpStatus
 import io.micronaut.test.annotation.Sql
 import jakarta.inject.Singleton
 import org.maurodata.api.facet.SemanticLinkCreateDTO
+import org.maurodata.domain.classifier.ClassificationScheme
+import org.maurodata.domain.classifier.Classifier
 import org.maurodata.domain.datamodel.DataClass
 import org.maurodata.domain.datamodel.DataElement
 import org.maurodata.domain.datamodel.DataModel
@@ -17,6 +19,7 @@ import org.maurodata.domain.terminology.Term
 import org.maurodata.domain.terminology.Terminology
 import org.maurodata.persistence.ContainerizedTest
 import org.maurodata.testing.CommonDataSpec
+import org.maurodata.web.ListResponse
 import spock.lang.Shared
 
 @ContainerizedTest
@@ -51,6 +54,9 @@ class DeleteFolderIntegrationSpec extends CommonDataSpec {
         CodeSet codeSet = codeSetApi.create(folderId, codeSet())
         codeSetApi.addTerm(codeSet.id, term.id)
 
+        ClassificationScheme classificationScheme = classificationSchemeApi.create(folderId, classificationSchemePayload(true, true))
+        Classifier classifier1 = classifierApi.create(classificationScheme.id, classifierPayload('classifier one label') )
+        Classifier classifier2 = classifierApi.create(classificationScheme.id, classifierPayload('classifier two label') )
         Folder folder = folderApi.show(folderId)
 
         when:
@@ -59,6 +65,17 @@ class DeleteFolderIntegrationSpec extends CommonDataSpec {
         then:
         response
         response.status() == HttpStatus.NO_CONTENT
+
+        when:
+        ClassificationScheme retrieved = classificationSchemeApi.show(classificationScheme.id)
+        then:
+        !retrieved
+
+        when:
+        ListResponse<Folder> listResponse = folderApi.listAll()
+        then:
+        listResponse.items.isEmpty()
+
     }
 
     void 'should delete folder and all associations - folder has reference to finalised model belonging to different folder'() {

--- a/mauro-api/src/test/groovy/org/maurodata/testing/CommonDataSpec.groovy
+++ b/mauro-api/src/test/groovy/org/maurodata/testing/CommonDataSpec.groovy
@@ -316,7 +316,7 @@ class CommonDataSpec extends Specification {
     }
     ClassificationScheme classificationSchemePayload(boolean readableByEveryone, boolean readableByAuthenticatedUsers){
         new ClassificationScheme(
-            label: 'classifiers label',
+            label: 'classification scheme label',
             description : 'random description',
             readableByEveryone: readableByEveryone,
             readableByAuthenticatedUsers: readableByAuthenticatedUsers)

--- a/mauro-domain/src/main/groovy/org/maurodata/FieldConstants.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/FieldConstants.groovy
@@ -1,0 +1,14 @@
+package org.maurodata
+
+class FieldConstants {
+
+    static final String CLASSIFICATION_SCHEME_LOWERCASE = 'classificationscheme'
+    static final String CLASSIFICATION_SCHEMES_LOWERCASE = "{$CLASSIFICATION_SCHEMES_LOWERCASE}s"
+    static final String CODESET_LOWERCASE = 'codeset'
+    static final String CODESETS_LOWERCASE = "{$CODESET_LOWERCASE}s"
+    static final String DATAMODEL_LOWERCASE = 'datamodel'
+    static final String DATAMODELS_LOWERCASE = "${DATAMODEL_LOWERCASE}s"
+    static final String TERMINOLOGY_LOWERCASE = 'terminology'
+    static final String TERMINOLOGIES_LOWERCASE = 'terminologies'
+
+}

--- a/mauro-domain/src/main/groovy/org/maurodata/Paths.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/Paths.groovy
@@ -1,1 +1,0 @@
-package org.maurodata

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/DataModelService.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/DataModelService.groovy
@@ -1,5 +1,6 @@
 package org.maurodata.domain.datamodel
 
+import org.maurodata.FieldConstants
 import org.maurodata.domain.model.ModelService
 
 import groovy.transform.CompileStatic
@@ -17,7 +18,7 @@ class DataModelService extends ModelService<DataModel> {
     }
 
     Boolean handles(String domainType) {
-        return domainType != null && domainType.toLowerCase() in ['datamodel', 'datamodels']
+        return domainType != null && domainType.toLowerCase() in [FieldConstants.DATAMODEL_LOWERCASE, FieldConstants.DATAMODELS_LOWERCASE]
     }
 
 

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/folder/Folder.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/folder/Folder.groovy
@@ -8,6 +8,7 @@ import io.micronaut.core.annotation.Introspected
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.data.annotation.*
 import jakarta.persistence.Transient
+import org.maurodata.domain.classifier.ClassificationScheme
 import org.maurodata.domain.datamodel.DataModel
 import org.maurodata.domain.model.AdministeredItem
 import org.maurodata.domain.model.Model
@@ -146,6 +147,9 @@ class Folder extends Model {
     @Relation(value = Relation.Kind.ONE_TO_MANY, mappedBy = 'codeSet')
     List<CodeSet> codeSets = []
 
+    @Relation(value = Relation.Kind.ONE_TO_MANY, mappedBy = 'classificationScheme')
+    List<ClassificationScheme> classificationSchemes = []
+
     @Override
     @Transient
     @JsonIgnore
@@ -210,7 +214,13 @@ class Folder extends Model {
                 it.folder = cloned
             }
         }
+        cloned.classificationSchemes = classificationSchemes.collect {
+            it.clone().tap {
+                it.folder = cloned
+            }
+        }
         cloned.codeSets = codeSets.collect {it.clone()}
+
         cloned.setAssociations()
         cloned
     }
@@ -234,6 +244,10 @@ class Folder extends Model {
         codeSets.each { codeSet ->
             codeSet.folder = this
             codeSet.setAssociations()
+        }
+        classificationSchemes.each { classificationScheme ->
+            classificationScheme.folder = this
+            classificationScheme.setAssociations()
         }
     }
 

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/terminology/CodeSetService.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/terminology/CodeSetService.groovy
@@ -2,6 +2,7 @@ package org.maurodata.domain.terminology
 
 import groovy.transform.CompileStatic
 import jakarta.inject.Singleton
+import org.maurodata.FieldConstants
 import org.maurodata.domain.model.ModelService
 
 /**
@@ -15,7 +16,7 @@ class CodeSetService extends ModelService<CodeSet> {
     }
 
     Boolean handles(String domainType) {
-        return domainType != null && domainType.toLowerCase() in ['codeset', 'codesets']
+        return domainType != null && domainType.toLowerCase() in [FieldConstants.CODESET_LOWERCASE, FieldConstants.CODESETS_LOWERCASE]
     }
 
 }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/terminology/TerminologyService.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/terminology/TerminologyService.groovy
@@ -1,6 +1,7 @@
 package org.maurodata.domain.terminology
 
 import groovy.transform.CompileStatic
+import org.maurodata.FieldConstants
 import org.maurodata.domain.model.ModelService
 import org.maurodata.domain.tree.TreeItem
 
@@ -18,7 +19,7 @@ class TerminologyService extends ModelService<Terminology> {
     }
 
     Boolean handles(String domainType) {
-        return domainType != null && domainType.toLowerCase() in ['terminology', 'terminologies']
+        return domainType != null && domainType.toLowerCase() in [FieldConstants.TERMINOLOGY_LOWERCASE, FieldConstants.TERMINOLOGIES_LOWERCASE]
     }
 
     /*

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/classifier/ClassificationSchemeRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/classifier/ClassificationSchemeRepository.groovy
@@ -5,6 +5,7 @@ import io.micronaut.core.annotation.Nullable
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
 import jakarta.inject.Inject
+import org.maurodata.FieldConstants
 import org.maurodata.domain.classifier.ClassificationScheme
 import org.maurodata.persistence.classifier.dto.ClassificationSchemeDTORepository
 import org.maurodata.persistence.model.ModelRepository
@@ -30,4 +31,9 @@ abstract class ClassificationSchemeRepository implements ModelRepository<Classif
     @Nullable
     abstract List<ClassificationScheme> findAllByFolderId(UUID folderId)
 
+
+    @Override
+    Boolean handles(String domainType){
+        return domainType != null && domainType.toLowerCase() in [FieldConstants.CLASSIFICATION_SCHEME_LOWERCASE, FieldConstants.CLASSIFICATION_SCHEMES_LOWERCASE ]
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/DataModelRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/DataModelRepository.groovy
@@ -3,6 +3,7 @@ package org.maurodata.persistence.datamodel
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.data.annotation.Query
 import io.micronaut.data.jdbc.annotation.JdbcRepository
+import org.maurodata.FieldConstants
 import org.maurodata.domain.datamodel.DataModel
 import org.maurodata.persistence.datamodel.dto.DataModelDTORepository
 import org.maurodata.persistence.model.ModelRepository
@@ -41,5 +42,11 @@ abstract class DataModelRepository implements ModelRepository<DataModel> {
 ''',
         nativeQuery = true)
     abstract List<DataModel> getAllModelsByNamespace(String namespace)
+
+
+    @Override
+    Boolean handles(String domainType) {
+        return domainType != null && domainType.toLowerCase() in [FieldConstants.DATAMODEL_LOWERCASE, FieldConstants.DATAMODELS_LOWERCASE]
+    }
 
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/model/ModelContentRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/model/ModelContentRepository.groovy
@@ -191,4 +191,8 @@ class ModelContentRepository<M extends Model> extends AdministeredItemContentRep
         it.multiFacetAwareItemId = item.id
         it.multiFacetAwareItem = item
     }
+
+    Boolean handles(String domainType) {
+        administeredItemRepository.handles(domainType)
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/model/ModelRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/model/ModelRepository.groovy
@@ -22,6 +22,7 @@ trait ModelRepository<M extends Model> implements AdministeredItemRepository<M> 
     List<M> readAllByParent(AdministeredItem item) {
         readAllByFolder((Folder) item)
     }
+
     @Nullable
     abstract List<M> findAllByFolderId(UUID folderId)
 
@@ -30,4 +31,6 @@ trait ModelRepository<M extends Model> implements AdministeredItemRepository<M> 
 
     @Nullable
     abstract M readByLabelAndModelVersion(String label, ModelVersion modelVersion)
+
+    abstract Boolean handles(String domainType)
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/CodeSetRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/CodeSetRepository.groovy
@@ -7,6 +7,7 @@ import io.micronaut.data.annotation.Query
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
 import jakarta.inject.Inject
+import org.maurodata.FieldConstants
 import org.maurodata.domain.terminology.CodeSet
 import org.maurodata.domain.terminology.Term
 import org.maurodata.persistence.model.ModelRepository
@@ -61,4 +62,9 @@ abstract class CodeSetRepository implements ModelRepository<CodeSet> {
     @Nullable
     @Override
     abstract List<CodeSet> findAllByFolderId(UUID folderId)
+
+    @Override
+    Boolean handles(String domainType) {
+        return domainType != null && domainType.toLowerCase() in [FieldConstants.CODESET_LOWERCASE, FieldConstants.CODESETS_LOWERCASE]
+    }
 }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/TerminologyRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/TerminologyRepository.groovy
@@ -6,6 +6,7 @@ import io.micronaut.data.annotation.Repository
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
 import jakarta.inject.Inject
+import org.maurodata.FieldConstants
 import org.maurodata.domain.terminology.Terminology
 import org.maurodata.persistence.model.ModelRepository
 import org.maurodata.persistence.terminology.dto.TerminologyDTORepository
@@ -34,6 +35,6 @@ abstract class TerminologyRepository implements ModelRepository<Terminology> {
 
     @Override
     Boolean handles(String domainType) {
-        return domainType != null && domainType.toLowerCase() in ['terminology', 'terminologies']
+        return domainType != null && domainType.toLowerCase() in [FieldConstants.TERMINOLOGY_LOWERCASE, FieldConstants.TERMINOLOGIES_LOWERCASE]
     }
 }


### PR DESCRIPTION
This PR raised from previous merge and addresses the issues here:
https://github.com/MauroDataMapper/mauro-micronaut/pull/193

Namely:
AdministrativeItemController - Item may not have parent -this is legitimate; address lines below:
 if (!parent){
            ErrorHandler.handleError(HttpStatus.UNPROCESSABLE_ENTITY, 'Parent is null')
        }

  Folder - include ClassificationScheme model in folder;
             - tidy the FolderContentRepository associations -handling of, in all methods 
             