### PR TITLE
Add Item lookup by Id

### DIFF
--- a/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/DataModel.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/DataModel.groovy
@@ -288,6 +288,7 @@ class DataModel extends Model implements ItemReferencer {
 
         ItemReferencerUtils.addItems(dataTypes, pathsBeingReferenced)
         ItemReferencerUtils.addItems(enumerationValues, pathsBeingReferenced)
+        ItemReferencerUtils.addItems(dataElements, pathsBeingReferenced)
         ItemReferencerUtils.addItems(dataClasses, pathsBeingReferenced)
         ItemReferencerUtils.addItem(parent, pathsBeingReferenced)
 
@@ -302,6 +303,7 @@ class DataModel extends Model implements ItemReferencer {
         parent = ItemReferencerUtils.replaceItemByIdentity(parent, replacements, notReplaced)
         dataTypes = ItemReferencerUtils.replaceItemsByIdentity(dataTypes, replacements, notReplaced)
         dataClasses = ItemReferencerUtils.replaceItemsByIdentity(dataClasses, replacements, notReplaced)
+        dataElements = ItemReferencerUtils.replaceItemsByIdentity(dataElements, replacements, notReplaced)
         enumerationValues = ItemReferencerUtils.replaceItemsByIdentity(enumerationValues, replacements, notReplaced)
     }
 
@@ -312,6 +314,7 @@ class DataModel extends Model implements ItemReferencer {
         intoDataModel.dataTypes = ItemUtils.copyItems(this.dataTypes, intoDataModel.dataTypes)
         intoDataModel.enumerationValues = ItemUtils.copyItems(this.enumerationValues, intoDataModel.enumerationValues)
         intoDataModel.dataClasses = ItemUtils.copyItems(this.dataClasses, intoDataModel.dataClasses)
+        intoDataModel.dataElements = ItemUtils.copyItems(this.dataElements, intoDataModel.dataElements)
         intoDataModel.modelType = ItemUtils.copyItem(this.modelType, intoDataModel.modelType)
         intoDataModel.dataModelType = ItemUtils.copyItem(this.dataModelType, intoDataModel.dataModelType)
     }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/DataType.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/DataType.groovy
@@ -238,10 +238,10 @@ class DataType extends ModelItem<DataModel> implements DiffableItem<DataType>, I
     List<ItemReference> retrieveItemReferences() {
         List<ItemReference> pathsBeingReferenced = [] + super.retrieveItemReferences()
 
-        ItemReferencerUtils.addItems(enumerationValues, pathsBeingReferenced)
-        ItemReferencerUtils.addIdType(modelResourceId, modelResourceDomainType, pathsBeingReferenced)
-        ItemReferencerUtils.addItem(referenceClass, pathsBeingReferenced)
-        ItemReferencerUtils.addItem(parent, pathsBeingReferenced)
+        ItemReferencerUtils.addItems(this.enumerationValues, pathsBeingReferenced)
+        ItemReferencerUtils.addIdType(this.modelResourceId, modelResourceDomainType, pathsBeingReferenced)
+        ItemReferencerUtils.addItem(this.@referenceClass, pathsBeingReferenced)
+        ItemReferencerUtils.addItem(this.parent, pathsBeingReferenced)
 
         return pathsBeingReferenced
     }
@@ -250,26 +250,27 @@ class DataType extends ModelItem<DataModel> implements DiffableItem<DataType>, I
     void replaceItemReferencesByIdentity(IdentityHashMap<Item, Item> replacements, List<Item> notReplaced) {
         super.replaceItemReferencesByIdentity(replacements, notReplaced)
 
-        parent = ItemReferencerUtils.replaceItemByIdentity(parent, replacements, notReplaced)
-        referenceClass = ItemReferencerUtils.replaceItemByIdentity(referenceClass, replacements, notReplaced)
+        this.parent = ItemReferencerUtils.replaceItemByIdentity(this.parent, replacements, notReplaced)
+        this.referenceClass = ItemReferencerUtils.replaceItemByIdentity(this.@referenceClass, replacements, notReplaced)
         // This is not possible on Items
         // modelResourceId = ItemReferencerUtils.replaceIdTypeByIdentity(modelResourceId, replacements)
-        enumerationValues = ItemReferencerUtils.replaceItemsByIdentity(enumerationValues, replacements, notReplaced)
+        this.enumerationValues = ItemReferencerUtils.replaceItemsByIdentity(this.@enumerationValues, replacements, notReplaced)
     }
 
     @Override
     void copyInto(Item into) {
         DataType intoDataType = (DataType) into
         // A cart before the horse: domainType in AdministeredItem depends on dataTypeKind
-        intoDataType.dataTypeKind = ItemUtils.copyItem(this.@dataTypeKind, intoDataType.dataTypeKind)
+        intoDataType.dataTypeKind = ItemUtils.copyItem(this.@dataTypeKind, intoDataType.@dataTypeKind)
         super.copyInto(into)
-        intoDataType.domainType = ItemUtils.copyItem(this.@domainType, intoDataType.domainType)
-        intoDataType.dataModel = ItemUtils.copyItem(this.@dataModel, intoDataType.dataModel)
-        intoDataType.referenceClass = ItemUtils.copyItem(this.@referenceClass, intoDataType.referenceClass)
-        intoDataType.modelResourceDomainType = ItemUtils.copyItem(this.@modelResourceDomainType, intoDataType.modelResourceDomainType)
-        intoDataType.modelResourceId = ItemUtils.copyItem(this.@modelResourceId, intoDataType.modelResourceId)
-        intoDataType.units = ItemUtils.copyItem(this.@units, intoDataType.units)
-        intoDataType.enumerationValues = ItemUtils.copyItems(this.@enumerationValues, intoDataType.enumerationValues)
+        intoDataType.domainType = ItemUtils.copyItem(this.domainType, intoDataType.domainType)
+        intoDataType.dataTypeKind = ItemUtils.copyItem(this.@dataTypeKind, intoDataType.@dataTypeKind)
+        intoDataType.dataModel = ItemUtils.copyItem(this.@dataModel, intoDataType.@dataModel)
+        intoDataType.referenceClass = ItemUtils.copyItem(this.@referenceClass, intoDataType.@referenceClass)
+        intoDataType.modelResourceDomainType = ItemUtils.copyItem(this.@modelResourceDomainType, intoDataType.@modelResourceDomainType)
+        intoDataType.modelResourceId = ItemUtils.copyItem(this.@modelResourceId, intoDataType.@modelResourceId)
+        intoDataType.units = ItemUtils.copyItem(this.@units, intoDataType.@units)
+        intoDataType.enumerationValues = ItemUtils.copyItems(this.@enumerationValues, intoDataType.@enumerationValues)
     }
 
     @Override

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/model/ItemReferencer.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/model/ItemReferencer.groovy
@@ -82,6 +82,37 @@ trait ItemReferencer {
         }
     }
 
+    /*
+        Given an ItemReferencer (e.g. a DataModel / VersionedFolder / Folder etc)
+        get a map of all id -> Item[]
+
+        Useful for finding any Item by id without having to traverse
+        but also for finding alternatively loaded items by id.
+        Example use: DataType.referenceClass may point to a DataClass that only has the id hydrated
+        use that id to find the DataClass in the model that has a label
+         */
+    @Transient
+    @JsonIgnore
+    Map<UUID, Set<Item>> itemLookupById() {
+        IdentityHashMap<Item, Set<Item>> predecessorMap = new IdentityHashMap<>()
+        this.predecessors(predecessorMap)
+
+        Map<UUID, Set<Item>> allItemLookup = new HashMap<>(predecessorMap.size())
+
+        predecessorMap.keySet().forEach {Item item ->
+
+            final UUID id = item.id
+            Set<Item> referencedItems = allItemLookup.get(id)
+            if (referencedItems == null) {
+                referencedItems = []
+                allItemLookup.put(id, referencedItems)
+            }
+            referencedItems << item
+        }
+
+        return allItemLookup
+    }
+
     /**
      A general deep clone does the following:
 


### PR DESCRIPTION
Add dataElements references to ItemReferencer for DataModel Make sure DataType replace references works Add method itemLookupById that, given any <I extends Item>, holds a map of UUID -> Set<Item> . This is useful for when an in-memory model holds 'stub' references to other items. For example, if a DataType is a ReferenceType, the DataClass that it references is a stub object only holding the id of the DataClass. To find the information you want, use the map returned by itemLookupById() to find all DataClass instances with the same id