### PR TITLE
createExportResponse to use content type returned by plugin

### DIFF
--- a/mauro-api/src/main/groovy/org/maurodata/controller/model/ModelController.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/controller/model/ModelController.groovy
@@ -8,6 +8,7 @@ import io.micronaut.core.annotation.Nullable
 import io.micronaut.http.HttpHeaders
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
+import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Body
 import io.micronaut.http.exceptions.HttpException
 import io.micronaut.http.exceptions.HttpStatusException
@@ -442,10 +443,16 @@ abstract class ModelController<M extends Model> extends AdministeredItemControll
     static protected HttpResponse<byte[]> createExportResponse(ModelExporterPlugin mauroPlugin, Model model) {
         byte[] fileContents = mauroPlugin.exportModel(model)
         String filename = mauroPlugin.getFileName(model)
+        String contentType = mauroPlugin.getContentType()
+        if (contentType == null) {
+            contentType = MediaType.APPLICATION_OCTET_STREAM
+        }
+
         HttpResponse
             .ok(fileContents)
             .header(HttpHeaders.CONTENT_LENGTH, Long.toString(fileContents.length))
             .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=${filename}")
+            .contentType(contentType)
     }
 
     protected VersionLinkDTO constructVersionLinkDTO(final M sourceModel, final VersionLink versionLink) {


### PR DESCRIPTION
Helps programs to decide how to deal with the contents. E.g. processing and opening, as well as transport (whether to encode or compress it over http)
