### PR TITLE
tweaks to import Databricks models

### DIFF
--- a/mauro-api/src/main/resources/application.yml
+++ b/mauro-api/src/main/resources/application.yml
@@ -6,9 +6,9 @@ micronaut:
 
   server:
     port: 8080
-    max-request-size: 100mb
+    max-request-size: 500mb
     multipart:
-      max-file-size: 100mb
+      max-file-size: 500mb
     cors:
       enabled: true
   router:

--- a/mauro-domain/src/main/groovy/org/maurodata/plugin/exporter/json/JsonFolderExporterPlugin.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/plugin/exporter/json/JsonFolderExporterPlugin.groovy
@@ -85,6 +85,7 @@ class JsonFolderExporterPlugin implements FolderExporterPlugin {
     }
 
     void addAllFoldersToMap(Folder folder, Map<UUID, Folder> foldersMap) {
+        if (!folder.id) folder.id = UUID.randomUUID()
         foldersMap[folder.id] = folder
         folder.childFolders.each {addAllFoldersToMap(it, foldersMap)}
     }

--- a/mauro-domain/src/main/groovy/org/maurodata/plugin/importer/json/JsonDataModelImporterPlugin.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/plugin/importer/json/JsonDataModelImporterPlugin.groovy
@@ -1,17 +1,15 @@
 package org.maurodata.plugin.importer.json
 
-import io.micronaut.http.HttpStatus
-import jakarta.inject.Inject
-import org.maurodata.ErrorHandler
-import org.maurodata.plugin.importer.DataModelImporterPlugin
-import org.maurodata.plugin.importer.FileImportParameters
-
 import com.fasterxml.jackson.databind.ObjectMapper
 import groovy.util.logging.Slf4j
+import io.micronaut.http.HttpStatus
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import org.maurodata.ErrorHandler
 import org.maurodata.domain.datamodel.DataModel
 import org.maurodata.export.ExportModel
-
-import jakarta.inject.Singleton
+import org.maurodata.plugin.importer.DataModelImporterPlugin
+import org.maurodata.plugin.importer.FileImportParameters
 
 @Slf4j
 @Singleton
@@ -31,13 +29,13 @@ class JsonDataModelImporterPlugin implements DataModelImporterPlugin<FileImportP
         log.info '** start importModel **'
         ExportModel importModel = objectMapper.readValue(params.importFile.fileContents, ExportModel)
         log.info '*** imported JSON model ***'
-        if (!importModel.dataModel && !importModel.dataModels){
+        if (!importModel.dataModel && !importModel.dataModels) {
             ErrorHandler.handleError(HttpStatus.BAD_REQUEST, 'Cannot import JSON as datamodel/s not present')
         }
-        if(importModel.dataModel) {
+        if (importModel.dataModel) {
             return [importModel.dataModel]
         } else {
-            return importModel.dataModels?:[]
+            return importModel.dataModels ?: []
         }
 
     }


### PR DESCRIPTION
Minor tweaks to import models from Databricks:
* increase max upload size
* set random folder IDs when importing if not set (e.g. from CLI tool) to allow splitting the folders into a map