### PR TITLE
Docker: Allow micronaut configuration to be split

### DIFF
--- a/mauro-api/build.gradle
+++ b/mauro-api/build.gradle
@@ -256,7 +256,7 @@ tasks.named("dockerfile") {
     baseImage("${dockerTag}")
 
     instruction """
-ENV MICRONAUT_ENVIRONMENTS=docker
+ENV MICRONAUT_ENVIRONMENTS='docker,datasources,javamail,mauro'
 ENV DATABASE_NAME=sandbox
 ENV DATABASE_USERNAME=sandbox
 ENV DATABASE_PASSWORD=sandbox


### PR DESCRIPTION
Allow micronaut configuration to be split between different aspects to aid targeted and abstracted configuration. These files don't have to exist, but if they do, they can override the base configuration:

* application-datasources.yml
* application-javamail.yml
* application-mauro.yml

These correspond to those same sections in application.yml, and will make explaining how to update configuration a lot easier!