### PR TITLE
Adds gradlew dockerBuildBackend

### DIFF
--- a/mauro-api/build.gradle
+++ b/mauro-api/build.gradle
@@ -174,7 +174,9 @@ def detectLTS=false
 
 def dockerTag="eclipse-temurin:${latestLts('eclipse-temurin',temurinDefault,detectLTS)}-jre-${latestLts('ubuntu',ubuntuDefault,detectLTS)}"
 
-def dockerIncludeDatabase = !gradle.startParameter.taskNames.any { it.contains('dockerBuild') && it.contains("NoDatabase") }
+def dockerIncludeDatabase = !gradle.startParameter.taskNames.any { it.contains('dockerBuild') && (it.contains("NoDatabase") || it.contains("Backend")) }
+def dockerIncludeUI = !gradle.startParameter.taskNames.any { it.contains('dockerBuild') && it.contains("Backend") }
+def dockerBackendOnly = !dockerIncludeDatabase && !dockerIncludeUI
 
 tasks.register('printDockerTag') {
     doLast {
@@ -191,6 +193,16 @@ tasks.register('printItOut') {
 
 tasks.register('fetchMDMUI') {
     doLast {
+        if(!dockerIncludeUI) {
+
+            if(uiTargetDir.exists()) {
+                println "Removing UI files"
+                project.delete(uiTargetDir)
+            }
+
+            return
+        }
+
         println "Fetching UI list from $uiRepoApi"
         def jsonText = new URI(uiRepoApi).toURL().getText(requestProperties: ['Accept': 'application/json'])
         def parsed = new JsonSlurper().parseText(jsonText)
@@ -257,12 +269,17 @@ tasks.named('dockerBuild') {
 }
 
 tasks.register('stageDockerFiles', Copy) {
+    def dockerMainScripts=project.layout.buildDirectory.dir("docker/main/scripts").get().asFile
+    if(dockerMainScripts.exists()){
+        delete(dockerMainScripts)
+    }
+    mkdir(dockerMainScripts)
     if(!dockerIncludeDatabase) {
         from file('docker/noDB')
-        into project.layout.buildDirectory.dir("docker/main").get().asFile
+        into dockerMainScripts
     } else {
         from file('docker/all')
-        into project.layout.buildDirectory.dir("docker/main").get().asFile
+        into dockerMainScripts
     }
 }
 
@@ -285,8 +302,8 @@ RUN mkdir -p \${LOGS_DIRECTORY}
 RUN mkdir -p \${INIT_DIR}
 VOLUME ["\${INIT_DIR}"]
 
-COPY micronaut/* /usr/local/bin/
-COPY startup/* /usr/local/bin/
+COPY scripts/micronaut/* /usr/local/bin/
+COPY scripts/startup/* /usr/local/bin/
 RUN chmod +x /usr/local/bin/*
 
 ENTRYPOINT ["docker-startup.sh"]
@@ -314,9 +331,9 @@ VOLUME ["\${DATABASE_SNAPSHOTS_DIRECTORY}"]
 RUN mkdir -p \${INIT_DIR}
 VOLUME ["\${INIT_DIR}"]
 
-COPY postgres/* /usr/local/bin/
-COPY micronaut/* /usr/local/bin/
-COPY startup/* /usr/local/bin/
+COPY scripts/postgres/* /usr/local/bin/
+COPY scripts/micronaut/* /usr/local/bin/
+COPY scripts/startup/* /usr/local/bin/
 RUN chmod +x /usr/local/bin/*
 
 EXPOSE 5432
@@ -349,10 +366,15 @@ tasks.register('dockerBuildMultiArch') {
         println "🐳 Running docker build with multi-arch buildx command..."
 
         def imageName
-        if(!dockerIncludeDatabase) {
-            imageName = "maurodatamapper/mauro:nodb-${version}"
-        } else {
-            imageName = "maurodatamapper/mauro:${version}"
+        if(dockerBackendOnly) {
+            imageName = "maurodatamapper/mauro:backend-${version}"
+        }
+        else {
+            if (!dockerIncludeDatabase) {
+                imageName = "maurodatamapper/mauro:nodb-${version}"
+            } else {
+                imageName = "maurodatamapper/mauro:${version}"
+            }
         }
         def location = project.layout.buildDirectory.dir("docker/main").get().asFile.absolutePath
 
@@ -369,5 +391,9 @@ tasks.register('dockerBuildNoDatabase') {
 }
 
 tasks.register('dockerBuildMultiArchNoDatabase') {
+    dependsOn(tasks.named('dockerBuildMultiArch'))
+}
+
+tasks.register('dockerBuildBackend') {
     dependsOn(tasks.named('dockerBuildMultiArch'))
 }


### PR DESCRIPTION
That builds a multi architecture maurodatamapper/mauro:backend-... image
A docker version with only the mauro micronaut backend: no database, no UI
Ensures that the UI is not included if it is present in the gradle build directory already
Deletes and re-copies docker scripts to the build directory
Tags this build mauro:backend-${version}