### PR TITLE
detectPluginsInDirectory log message

### DIFF
--- a/mauro-domain/src/main/groovy/org/maurodata/plugin/MauroPluginService.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/plugin/MauroPluginService.groovy
@@ -71,7 +71,7 @@ class MauroPluginService {
         }
 
         if (pluginsDirPath == null) {
-            log.error("Failed to locate plugins directory")
+            log.warn("Failed to locate plugins directory")
             return
         }
 


### PR DESCRIPTION
If there is not a plugin directory, it is actually a warning rather than an error