### PR TITLE
Removes parent axis from retrieveItemReferences()

### DIFF
--- a/mauro-domain/src/main/groovy/org/maurodata/domain/classifier/ClassificationScheme.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/classifier/ClassificationScheme.groovy
@@ -121,7 +121,6 @@ class ClassificationScheme extends Model implements ItemReferencer {
     List<ItemReference> retrieveItemReferences() {
         List<ItemReference> pathsBeingReferenced = [] + super.retrieveItemReferences()
 
-        ItemReferencerUtils.addItem(parent, pathsBeingReferenced)
         ItemReferencerUtils.addItems(csClassifiers, pathsBeingReferenced)
 
         return pathsBeingReferenced

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/classifier/Classifier.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/classifier/Classifier.groovy
@@ -140,7 +140,6 @@ class Classifier extends ModelItem<ClassificationScheme> implements DiffableItem
 
         ItemReferencerUtils.addItem(classificationScheme, pathsBeingReferenced)
         ItemReferencerUtils.addItems(childClassifiers, pathsBeingReferenced)
-        ItemReferencerUtils.addItem(parentClassifier, pathsBeingReferenced)
 
         return pathsBeingReferenced
     }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/DataClass.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/DataClass.groovy
@@ -261,8 +261,6 @@ class DataClass extends ModelItem<DataModel> implements DiffableItem<DataClass>,
         ItemReferencerUtils.addItems(dataClasses, pathsBeingReferenced)
 
         ItemReferencerUtils.addItems(referenceTypes, pathsBeingReferenced)
-        ItemReferencerUtils.addItem(parentDataClass, pathsBeingReferenced)
-        ItemReferencerUtils.addItem(dataModel, pathsBeingReferenced)
         ItemReferencerUtils.addItems(extendsDataClasses, pathsBeingReferenced)
         ItemReferencerUtils.addItems(extendedBy, pathsBeingReferenced)
 

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/DataElement.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/DataElement.groovy
@@ -237,9 +237,7 @@ class DataElement extends ModelItem<DataClass> implements DiffableItem<DataEleme
     List<ItemReference> retrieveItemReferences() {
         List<ItemReference> pathsBeingReferenced = [] + super.retrieveItemReferences()
 
-        ItemReferencerUtils.addItem(dataClass, pathsBeingReferenced)
         ItemReferencerUtils.addItem(dataType, pathsBeingReferenced)
-        ItemReferencerUtils.addItem(dataModel, pathsBeingReferenced)
 
         return pathsBeingReferenced
     }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/DataModel.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/DataModel.groovy
@@ -311,7 +311,6 @@ class DataModel extends Model implements ItemReferencer {
         ItemReferencerUtils.addItems(enumerationValues, pathsBeingReferenced)
         ItemReferencerUtils.addItems(dataElements, pathsBeingReferenced)
         ItemReferencerUtils.addItems(dataClasses, pathsBeingReferenced)
-        ItemReferencerUtils.addItem(parent, pathsBeingReferenced)
 
         return pathsBeingReferenced
     }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/DataType.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/DataType.groovy
@@ -260,7 +260,6 @@ class DataType extends ModelItem<DataModel> implements DiffableItem<DataType>, I
         ItemReferencerUtils.addItems(this.enumerationValues, pathsBeingReferenced)
         ItemReferencerUtils.addIdType(this.modelResourceId, modelResourceDomainType, pathsBeingReferenced)
         ItemReferencerUtils.addItem(this.@referenceClass, pathsBeingReferenced)
-        ItemReferencerUtils.addItem(this.parent, pathsBeingReferenced)
 
         return pathsBeingReferenced
     }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/EnumerationValue.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/EnumerationValue.groovy
@@ -157,9 +157,6 @@ class EnumerationValue extends ModelItem<DataModel> implements DiffableItem<Enum
     List<ItemReference> retrieveItemReferences() {
         List<ItemReference> pathsBeingReferenced = [] + super.retrieveItemReferences()
 
-        ItemReferencerUtils.addItem(enumerationType, pathsBeingReferenced)
-        ItemReferencerUtils.addItem(dataModel, pathsBeingReferenced)
-
         return pathsBeingReferenced
     }
 

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/facet/Facet.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/facet/Facet.groovy
@@ -90,7 +90,6 @@ abstract class Facet extends Item implements Pathable, ItemReferencer {
     List<ItemReference> retrieveItemReferences() {
         List<ItemReference> pathsBeingReferenced = [] + super.retrieveItemReferences()
 
-        ItemReferencerUtils.addItem(multiFacetAwareItem, pathsBeingReferenced)
         ItemReferencerUtils.addIdType(multiFacetAwareItemId, multiFacetAwareItemDomainType, pathsBeingReferenced)
 
         return pathsBeingReferenced

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/folder/Folder.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/folder/Folder.groovy
@@ -234,7 +234,6 @@ class Folder extends Model implements ItemReferencer {
         ItemReferencerUtils.addItems(terminologies, pathsBeingReferenced)
         ItemReferencerUtils.addItems(codeSets, pathsBeingReferenced)
         ItemReferencerUtils.addItems(classificationSchemes, pathsBeingReferenced)
-        ItemReferencerUtils.addItem(parentFolder, pathsBeingReferenced)
 
         return pathsBeingReferenced
     }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/model/Model.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/model/Model.groovy
@@ -322,7 +322,6 @@ abstract class Model<M extends DiffableItem> extends AdministeredItem implements
     List<ItemReference> retrieveItemReferences() {
         List<ItemReference> pathsBeingReferenced = [] + super.retrieveItemReferences()
 
-        ItemReferencerUtils.addItem(folder, pathsBeingReferenced)
         ItemReferencerUtils.addItem(authority, pathsBeingReferenced)
 
         return pathsBeingReferenced

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/terminology/Term.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/terminology/Term.groovy
@@ -172,7 +172,6 @@ class Term extends ModelItem<Terminology> implements ItemReferencer {
     List<ItemReference> retrieveItemReferences() {
         List<ItemReference> pathsBeingReferenced = [] + super.retrieveItemReferences()
 
-        ItemReferencerUtils.addItem(terminology, pathsBeingReferenced)
         ItemReferencerUtils.addItems(sourceTermRelationships, pathsBeingReferenced)
         ItemReferencerUtils.addItems(targetTermRelationships, pathsBeingReferenced)
         ItemReferencerUtils.addItems(codeSets, pathsBeingReferenced)

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/terminology/TermRelationship.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/terminology/TermRelationship.groovy
@@ -129,7 +129,6 @@ class TermRelationship extends ModelItem<Terminology> implements ItemReferencer 
     List<ItemReference> retrieveItemReferences() {
         List<ItemReference> pathsBeingReferenced = [] + super.retrieveItemReferences()
 
-        ItemReferencerUtils.addItem(terminology, pathsBeingReferenced)
         ItemReferencerUtils.addItem(sourceTerm, pathsBeingReferenced)
         ItemReferencerUtils.addItem(targetTerm, pathsBeingReferenced)
         ItemReferencerUtils.addItem(relationshipType, pathsBeingReferenced)

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/terminology/TermRelationshipType.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/terminology/TermRelationshipType.groovy
@@ -122,7 +122,6 @@ class TermRelationshipType extends ModelItem<Terminology> implements ItemReferen
     List<ItemReference> retrieveItemReferences() {
         List<ItemReference> pathsBeingReferenced = [] + super.retrieveItemReferences()
 
-        ItemReferencerUtils.addItem(terminology, pathsBeingReferenced)
         ItemReferencerUtils.addItems(termRelationships, pathsBeingReferenced)
 
         return pathsBeingReferenced


### PR DESCRIPTION
Perhaps the parent axis items do not need to be returned (but do need to be replaced) because that Item will always be 'in your hand'. This may speed up cloning / - to be tested on the DD with createNewBranchModelVersion ?