### PR TITLE
Ensure available actions appear for DataElement

### DIFF
--- a/mauro-api/src/main/groovy/org/maurodata/controller/datamodel/DataElementController.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/controller/datamodel/DataElementController.groovy
@@ -68,10 +68,13 @@ class DataElementController extends AdministeredItemController<DataElement, Data
     @Audit
     @Get(Paths.DATA_ELEMENT_ID)
     DataElement show(UUID dataModelId, UUID dataClassId, UUID id) {
+        log.debug("DataElementController show ${id}")
         DataElement dataElement = super.show(id) as DataElement
         if (dataElement.dataType.isEnumerationType()) {
             dataElement.dataType = dataTypeService.getEnumerationValues(dataElement.dataType)
         }
+        log.debug("DataElementController show dataElement.availableActions ${dataElement.availableActions}")
+
         dataElement
     }
 

--- a/mauro-api/src/main/groovy/org/maurodata/controller/tree/TreeController.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/controller/tree/TreeController.groovy
@@ -99,10 +99,10 @@ class TreeController implements TreeApi {
                 it.modelVersion = ((Model) it.item).modelVersion
                 it.modelVersionTag = ((Model) it.item).modelVersionTag
             }
-            it.availableActions = new ArrayList<String>(it.item.availableActions)
+            it.availableActions = new ArrayList<String>(it.item.availableActions?:[])
             it.children.each {
                 AvailableActions.updateAvailableActions(it.item, accessControlService)
-                it.availableActions = new ArrayList<String>(it.item.availableActions)
+                it.availableActions = new ArrayList<String>(it.item.availableActions?:[])
                 if (it.item instanceof Model) {
                     it.modelVersion = ((Model) it.item).modelVersion
                     it.modelVersionTag = ((Model) it.item).modelVersionTag

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/model/AdministeredItem.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/model/AdministeredItem.groovy
@@ -114,7 +114,8 @@ abstract class AdministeredItem extends Item implements Pathable {
     List<ReferenceFile> referenceFiles = []
 
     @Transient
-    List<String> availableActions = []
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    List<String> availableActions = null
 
     @Relation(Relation.Kind.ONE_TO_MANY)
     List<SemanticLink> semanticLinks = []
@@ -153,7 +154,7 @@ abstract class AdministeredItem extends Item implements Pathable {
         intoAdministeredItem.aliasesString = ItemUtils.copyItem(this.aliasesString, intoAdministeredItem.aliasesString)
         intoAdministeredItem.path = ItemUtils.copyItem(this.path, intoAdministeredItem.path)
         if (intoAdministeredItem.breadcrumbs != null) {intoAdministeredItem.breadcrumbs = [] + this.breadcrumbs}
-        intoAdministeredItem.availableActions = [] + this.availableActions
+        intoAdministeredItem.availableActions = this.availableActions != null? ([] + this.availableActions) : null
         intoAdministeredItem.breadcrumbTreeId = ItemUtils.copyItem(this.breadcrumbTreeId, intoAdministeredItem.breadcrumbTreeId)
         intoAdministeredItem.edits = ItemUtils.copyItem(this.edits, intoAdministeredItem.edits)
         intoAdministeredItem.metadata = ItemUtils.copyItem(this.metadata, intoAdministeredItem.metadata)

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/tree/TreeItem.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/tree/TreeItem.groovy
@@ -53,7 +53,7 @@ class TreeItem {
     }
 
     static TreeItem from(AdministeredItem item) {
-        new TreeItem(id: item.id, label: item.label, domainType: item.domainType, item: item, availableActions: new ArrayList<String>(item.availableActions),
+        new TreeItem(id: item.id, label: item.label, domainType: item.domainType, item: item, availableActions: new ArrayList<String>(item.availableActions?:[]),
                      path: item.updatePath().toString(), model: item.getOwner(), parent: item.getParent(),
                      branchName: (item instanceof Model)? item.branchName : null,
                      modelVersion: (item instanceof Model)? item.modelVersion : null,


### PR DESCRIPTION
For some AdministeredItems, the owner is a stub record. AccessControlService canDoRole() and listCanDoRoles() load in the owner from a repository when the catalogue user is not loaded

Ensure that availableActions is always sent to the client even if the list is empty