### PR TITLE
Increase micronaut version to 4.9.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-micronautVersion=4.7.3
+micronautVersion=4.9.4
 group=org.maurodata
 version=0.0.3-SNAPSHOT
 # (optional, if you want Vanniktech to read them too)


### PR DESCRIPTION
to increase the versions used by io.micronaut:micronaut-core-bom to latest ones that also remain backwards compatible

Checked with:

% cd mauro-api
% ../gradlew dependencies --configuration runtimeClasspath

https://mvnrepository.com/artifact/io.micronaut.platform/micronaut-platform