### PR TITLE
Change default batch size to 10,000

### DIFF
--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/ContentHandler.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/ContentHandler.groovy
@@ -105,7 +105,7 @@ class ContentHandler {
     @Inject SummaryMetadataReportCacheableRepository summaryMetadataReportCacheableRepository
     @Inject VersionLinkCacheableRepository versionLinkCacheableRepository
 
-    int batchSize = 1000
+    int batchSize = 10000
 
     Map<UUID, AdministeredItem> allItems = [:]
 


### PR DESCRIPTION
Based on one run, and one large versioned folder, times taken to create and delete a new branch.

Batch size | 1,000 | 10,000 | 50,000 |
--- | --- | --- | --- |
Create | 66.1 | 62.5 | 80.0 | 
Delete | 11.4 | 11.6 | 11.4 | 