### PR TITLE
OpenIDConnect redirection

### DIFF
--- a/mauro-api/src/main/groovy/org/maurodata/security/authentication/MauroSessionLoginHandler.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/security/authentication/MauroSessionLoginHandler.groovy
@@ -6,6 +6,7 @@ import io.micronaut.context.annotation.Replaces
 import io.micronaut.context.annotation.Value
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.http.*
+import io.micronaut.http.cookie.Cookie
 import io.micronaut.security.authentication.Authentication
 import io.micronaut.security.authentication.AuthenticationResponse
 import io.micronaut.security.config.RedirectConfiguration
@@ -57,7 +58,16 @@ class MauroSessionLoginHandler extends SessionLoginHandler {
                 log.debug 'Successful login, redirecting to login success URI'
                 MutableHttpResponse<?> response = HttpResponse.status(HttpStatus.SEE_OTHER)
                 MutableHttpHeaders headers = response.headers as MutableHttpHeaders
-                headers.location(loginSuccessUrl)
+                URI redirectUri = loginSuccessUrl
+                try {
+                    Optional<Cookie> redirectCookie = request.getCookies().findCookie(OAuthRedirectFilter.UI_REDIRECT_URL)
+                    if(redirectCookie.get()) {
+                        redirectUri = URI.create(redirectCookie.get().value)
+                    }
+                } catch (Exception e) {
+                    log.warn("Invalid value for Cookie '${OAuthRedirectFilter.UI_REDIRECT_URL}")
+                }
+                headers.location(redirectUri)
                 response
             }
         } else {

--- a/mauro-api/src/main/groovy/org/maurodata/security/authentication/MauroSessionLoginHandler.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/security/authentication/MauroSessionLoginHandler.groovy
@@ -61,7 +61,7 @@ class MauroSessionLoginHandler extends SessionLoginHandler {
                 URI redirectUri = loginSuccessUrl
                 try {
                     Optional<Cookie> redirectCookie = request.getCookies().findCookie(OAuthRedirectFilter.UI_REDIRECT_URL)
-                    if(redirectCookie.get()) {
+                    if(redirectCookie && redirectCookie.get()) {
                         redirectUri = URI.create(redirectCookie.get().value)
                     }
                 } catch (Exception e) {

--- a/mauro-api/src/main/groovy/org/maurodata/security/authentication/OAuthRedirectFilter.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/security/authentication/OAuthRedirectFilter.groovy
@@ -29,7 +29,6 @@ class OAuthRedirectFilter implements HttpServerFilter {
 
         String host = httpHostResolver.resolve(request)
         URI requestHostURI = new URI(host)
-        requestHostURI.scheme
 
         // Use Mono.from to turn publisher -> Mono, then map the response
         return Mono.from(chain.proceed(request))

--- a/mauro-api/src/main/groovy/org/maurodata/security/authentication/OAuthRedirectFilter.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/security/authentication/OAuthRedirectFilter.groovy
@@ -8,6 +8,8 @@ import io.micronaut.http.cookie.Cookie
 import io.micronaut.http.cookie.SameSite
 import io.micronaut.http.filter.HttpServerFilter
 import io.micronaut.http.filter.ServerFilterChain
+import io.micronaut.http.server.util.HttpHostResolver
+import jakarta.inject.Inject
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Mono
 
@@ -17,16 +19,24 @@ class OAuthRedirectFilter implements HttpServerFilter {
 
     static final String UI_REDIRECT_URL = "ui_redirect_url"
 
+    @Inject HttpHostResolver httpHostResolver
+
+
     @Override
     Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain ) { // (1)
         String redirectUri = null
         redirectUri = request.getParameters().get("redirect_uri")
+
+        String host = httpHostResolver.resolve(request)
+        URI requestHostURI = new URI(host)
+        requestHostURI.scheme
+
         // Use Mono.from to turn publisher -> Mono, then map the response
         return Mono.from(chain.proceed(request))
             .map { MutableHttpResponse<?> resp ->
                 if(redirectUri) {
                     Cookie cookie = Cookie.of(UI_REDIRECT_URL, redirectUri)
-                        .secure(false) // For local dev remove secure; in prod keep it
+                        .secure(requestHostURI.scheme == "https")
                         .sameSite(SameSite.None)
                         .httpOnly(true)
                         .path("/")

--- a/mauro-api/src/main/groovy/org/maurodata/security/authentication/OAuthRedirectFilter.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/security/authentication/OAuthRedirectFilter.groovy
@@ -20,11 +20,7 @@ class OAuthRedirectFilter implements HttpServerFilter {
     @Override
     Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain ) { // (1)
         String redirectUri = null
-        try {
-            redirectUri = request.getParameters().get("redirect_uri")
-        } catch (Exception e) {
-            log.warn("No redirect uri specified for login")
-        }
+        redirectUri = request.getParameters().get("redirect_uri")
         // Use Mono.from to turn publisher -> Mono, then map the response
         return Mono.from(chain.proceed(request))
             .map { MutableHttpResponse<?> resp ->

--- a/mauro-api/src/main/groovy/org/maurodata/security/authentication/OAuthRedirectFilter.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/security/authentication/OAuthRedirectFilter.groovy
@@ -1,0 +1,41 @@
+package org.maurodata.security.authentication
+
+import groovy.util.logging.Slf4j
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MutableHttpResponse
+import io.micronaut.http.annotation.Filter
+import io.micronaut.http.cookie.Cookie
+import io.micronaut.http.cookie.SameSite
+import io.micronaut.http.filter.HttpServerFilter
+import io.micronaut.http.filter.ServerFilterChain
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Mono
+
+@Slf4j
+@Filter("/oauth/login/**")
+class OAuthRedirectFilter implements HttpServerFilter {
+
+    static final String UI_REDIRECT_URL = "ui_redirect_url"
+
+    @Override
+    Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain ) { // (1)
+        String redirectUri = null
+        try {
+            redirectUri = request.getParameters().get("redirect_uri")
+        } catch (Exception e) {
+            log.warn("No redirect uri specified for login")
+        }
+        // Use Mono.from to turn publisher -> Mono, then map the response
+        return Mono.from(chain.proceed(request))
+            .map { MutableHttpResponse<?> resp ->
+                Cookie cookie = Cookie.of(UI_REDIRECT_URL, redirectUri)
+                    .secure(false)   // For local dev remove secure; in prod keep it
+                    .sameSite(SameSite.None)
+                    .httpOnly(true)
+                    .path("/")
+                    .maxAge(300)
+                resp.cookie(cookie)  // attaches cookie to the outgoing response
+                return resp
+            } as Publisher<MutableHttpResponse<?>>
+    }
+}

--- a/mauro-api/src/main/groovy/org/maurodata/security/authentication/OAuthRedirectFilter.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/security/authentication/OAuthRedirectFilter.groovy
@@ -28,13 +28,15 @@ class OAuthRedirectFilter implements HttpServerFilter {
         // Use Mono.from to turn publisher -> Mono, then map the response
         return Mono.from(chain.proceed(request))
             .map { MutableHttpResponse<?> resp ->
-                Cookie cookie = Cookie.of(UI_REDIRECT_URL, redirectUri)
-                    .secure(false)   // For local dev remove secure; in prod keep it
-                    .sameSite(SameSite.None)
-                    .httpOnly(true)
-                    .path("/")
-                    .maxAge(300)
-                resp.cookie(cookie)  // attaches cookie to the outgoing response
+                if(redirectUri) {
+                    Cookie cookie = Cookie.of(UI_REDIRECT_URL, redirectUri)
+                        .secure(false) // For local dev remove secure; in prod keep it
+                        .sameSite(SameSite.None)
+                        .httpOnly(true)
+                        .path("/")
+                        .maxAge(300)
+                    resp.cookie(cookie) // attaches cookie to the outgoing response
+                }
                 return resp
             } as Publisher<MutableHttpResponse<?>>
     }

--- a/mauro-api/src/test/groovy/org/maurodata/security/MauroSessionLoginHandlerIntegrationSpec.groovy
+++ b/mauro-api/src/test/groovy/org/maurodata/security/MauroSessionLoginHandlerIntegrationSpec.groovy
@@ -57,11 +57,6 @@ class MauroSessionLoginHandlerIntegrationSpec extends SecuredIntegrationSpec {
         }
 
         @Override
-        Cookies getCookies() {
-            return cookies
-        }
-
-        @Override
         URI getUri() {
             return UriBuilder.of(KEYCLOAK_LOGIN_PATH).build()
         }


### PR DESCRIPTION
When starting OAuth authentication, add a cookie containing the path to redirect to (if set).  When finishing authentication, read the cookie and redirect to that path.