### PR TITLE
Adds configuration for lists of oauth entries

### DIFF
--- a/mauro-api/src/main/groovy/org/maurodata/controller/bootstrap/MauroConfiguration.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/controller/bootstrap/MauroConfiguration.groovy
@@ -1,6 +1,6 @@
 package org.maurodata.controller.bootstrap
 
-import groovy.beans.Bindable
+
 import groovy.transform.CompileStatic
 import io.micronaut.context.annotation.ConfigurationProperties
 import io.micronaut.core.annotation.Nullable
@@ -16,6 +16,7 @@ class MauroConfiguration {
     List<UserGroupConfig> groups
     List<ApiKeyConfig> apiKeys
     List<ApiPropertyConfig> apiProperties
+    List<OAuthConfig> oauths
 
     static class CatalogueUserConfig {
 
@@ -62,5 +63,24 @@ class MauroConfiguration {
         @Nullable
         @NotBlank
         String category
+    }
+
+    static class OAuthConfig {
+        @NotBlank
+        String oauthProvider
+        @Nullable
+        Boolean createUser
+        @Nullable
+        Boolean requireVerifiedEmail
+        @Nullable
+        Map<String, String> tokenCustomValidation
+        @NotBlank
+        String appLabel
+        @Nullable
+        @NotBlank
+        String appImageUrl
+        @Nullable
+        @NotBlank
+        String appLoginSuccess
     }
 }

--- a/mauro-api/src/main/groovy/org/maurodata/controller/security/openidprovider/OpenidProviderController.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/controller/security/openidprovider/OpenidProviderController.groovy
@@ -4,15 +4,24 @@ import org.maurodata.api.Paths
 import org.maurodata.api.security.openidprovider.OpenidConnectProvider
 import org.maurodata.api.security.openidprovider.OpenidProviderApi
 import org.maurodata.audit.Audit
+import org.maurodata.controller.bootstrap.MauroConfiguration
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import io.micronaut.context.annotation.Value
 import io.micronaut.core.annotation.Nullable
+import io.micronaut.http.HttpRequest
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
+import io.micronaut.http.context.ServerContextPathProvider
+import io.micronaut.http.server.HttpServerConfiguration
+import io.micronaut.http.server.util.HttpHostResolver
+import io.micronaut.http.ssl.SslConfiguration
+import io.micronaut.http.uri.UriBuilder
 import io.micronaut.security.annotation.Secured
+import io.micronaut.security.oauth2.url.OauthRouteUrlBuilder
 import io.micronaut.security.rules.SecurityRule
+import jakarta.inject.Inject
 
 @CompileStatic
 @Slf4j
@@ -40,16 +49,111 @@ class OpenidProviderController implements OpenidProviderApi {
     @Value('${mauro.oauth.image-url}')
     String imageUrl
 
+    @Inject
+    MauroConfiguration mauroConfiguration
+
+    @Inject
+    OauthRouteUrlBuilder oauthRouteUrlBuilder
+
+    @Inject
+    ServerContextPathProvider serverContextPathProvider
+
+    @Inject
+    HttpHostResolver httpHostResolver
+
+    @Inject
+    SslConfiguration sslConfig
+
+    @Inject
+    HttpServerConfiguration httpServerConfiguration
+
     @Audit
     @Get(Paths.OPENID_PROVIDER_LIST)
-    List<OpenidConnectProvider> list() {
-        if(!openidProviderId || !label || !standardProvider || !authorizationEndpoint) {
+    List<OpenidConnectProvider> list(@Nullable HttpRequest<?> request = null) {
+
+        boolean fromOauthSingular = openidProviderId && label && standardProvider && authorizationEndpoint
+        boolean fromOauthsList = (mauroConfiguration.oauths != null && !mauroConfiguration.oauths.isEmpty())
+
+        if (!fromOauthSingular && !fromOauthsList) {
             log.debug("No OpenID Connect Provider configured (mauro.oauth.{id, label, standard-provider, authorization-endpoint, image-url} is not set)")
             return []
         }
-        OpenidConnectProvider openidConnectProvider = new OpenidConnectProvider(openidProviderId, label, standardProvider, authorizationEndpoint,
-                imageUrl)
-        [openidConnectProvider]
+
+        if (!fromOauthsList && fromOauthSingular) {
+            OpenidConnectProvider openidConnectProvider = new OpenidConnectProvider(openidProviderId, label, standardProvider, authorizationEndpoint,
+                                                                                    imageUrl)
+            return [openidConnectProvider]
+        }
+
+        if (fromOauthsList) {
+
+            final List<OpenidConnectProvider> openidConnectProviders = []
+
+            // Get the base scheme, host, port so that the local starting authorization endpoint
+            // can be used as an external absolute URL
+            URI requestHostURI
+
+            if (request) {
+                String host = httpHostResolver.resolve(request)
+                requestHostURI = new URI(host)
+            } else {
+                log.warn("Constructed base URI from server configuration")
+                requestHostURI = UriBuilder.of("/")
+                    .scheme(sslConfig.isEnabled() ? 'https' : 'http')
+                    .host(httpServerConfiguration.host.present ? httpServerConfiguration.host.get() : 'localhost')
+                    .port(httpServerConfiguration.port.present ? httpServerConfiguration.port.get() : sslConfig.isEnabled() ? 443 : 80)
+                    .build()
+            }
+
+            String contextPath = serverContextPathProvider.getContextPath() ?: ""
+
+            mauroConfiguration.oauths.forEach {MauroConfiguration.OAuthConfig oAuthConfig ->
+
+                final String providerName = oAuthConfig.oauthProvider
+
+                // Get the login URI
+                URI loginURI = oauthRouteUrlBuilder.buildLoginUri(providerName)
+                String loginPath = loginURI.isAbsolute() ? loginURI.toString() : UriBuilder.of("/")
+                    .scheme(requestHostURI.scheme)
+                    .host(requestHostURI.host)
+                    .port(requestHostURI.port)
+                    .path(loginURI.getPath())
+                    .build()
+                    .toString()
+
+                // A helpful warning
+                if (contextPath && contextPath != '/' && !loginURI.getPath().startsWith(contextPath)) {
+
+                    String meantLoginPath = loginURI.isAbsolute() ? loginURI.toString() : UriBuilder.of("/")
+                        .path(contextPath)
+                        .path(loginURI.getPath())
+                        .build()
+                        .toString()
+
+                    URI callbackURI = oauthRouteUrlBuilder.buildCallbackUri(providerName)
+
+                    String meantCallbackPath = loginURI.isAbsolute() ? callbackURI.toString() : UriBuilder.of("/")
+                        .path(contextPath)
+                        .path(callbackURI.getPath())
+                        .build()
+                        .toString()
+
+                    log.warn("OAUTH: the login template at micronaut.security.oauth2.login-uri does not start with context-path at micronaut.server.context-path")
+                    log.info("Perhaps you meant:")
+                    log.info("OAUTH: micronaut.security.oauth2.login-uri = ${meantLoginPath}")
+                    log.info("OAUTH: micronaut.security.oauth2.callback-uri = ${meantCallbackPath}")
+                }
+
+                OpenidConnectProvider openidConnectProvider = new OpenidConnectProvider(
+                    null, oAuthConfig.appLabel, true, loginPath,
+                    oAuthConfig.appImageUrl)
+                openidConnectProviders << openidConnectProvider
+            }
+            return openidConnectProviders
+
+        }
+
+        return []
     }
 
 }

--- a/mauro-api/src/main/groovy/org/maurodata/security/authentication/MauroOpenIdAuthenticationMapper.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/security/authentication/MauroOpenIdAuthenticationMapper.groovy
@@ -1,5 +1,7 @@
 package org.maurodata.security.authentication
 
+import org.maurodata.controller.bootstrap.MauroConfiguration
+
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import io.micronaut.context.annotation.Property
@@ -9,7 +11,6 @@ import io.micronaut.security.authentication.AuthenticationException
 import io.micronaut.security.config.AuthenticationModeConfiguration
 import io.micronaut.security.oauth2.configuration.OpenIdAdditionalClaimsConfiguration
 import io.micronaut.security.oauth2.endpoint.token.response.DefaultOpenIdAuthenticationMapper
-import io.micronaut.security.oauth2.endpoint.token.response.OpenIdAuthenticationMapper
 import io.micronaut.security.oauth2.endpoint.token.response.OpenIdClaims
 import io.micronaut.security.oauth2.endpoint.token.response.OpenIdTokenResponse
 import io.micronaut.transaction.annotation.Transactional
@@ -37,6 +38,9 @@ class MauroOpenIdAuthenticationMapper extends DefaultOpenIdAuthenticationMapper 
     @Inject
     ItemCacheableRepository.CatalogueUserCacheableRepository catalogueUserCacheableRepository
 
+    @Inject
+    MauroConfiguration mauroConfiguration
+
     MauroOpenIdAuthenticationMapper(OpenIdAdditionalClaimsConfiguration openIdAdditionalClaimsConfiguration, AuthenticationModeConfiguration authenticationModeConfiguration) {
         super(openIdAdditionalClaimsConfiguration, authenticationModeConfiguration)
     }
@@ -46,47 +50,74 @@ class MauroOpenIdAuthenticationMapper extends DefaultOpenIdAuthenticationMapper 
     Map<String, Object> buildAttributes(String providerName, OpenIdTokenResponse tokenResponse, OpenIdClaims openIdClaims) {
         Map<String, Object> claims = super.buildAttributes(providerName, tokenResponse, openIdClaims)
         if (!claims.email) authenticationException("Attempt to login with no  email address specified!")
-        if (requireVerifiedEmail && !claims.email_verified) authenticationException("Attempt to login with unverified email address! [${claims.email}]") // Entra does not provide email_verified
 
-        tokenCustomValidation.each { expectedKey, expectedValue ->
-            Object tokenValue = claims[expectedKey]
+        claims.put("provider-name", providerName)
 
-            boolean invalid =
-                    tokenValue == null ||
-                    (tokenValue instanceof String && tokenValue != expectedValue) ||
-                    (tokenValue instanceof Collection<?> && !((Collection<?>)tokenValue).contains(expectedValue))
+        boolean toCreateUser = createUser
+        boolean toRequireVerifiedEmail = requireVerifiedEmail
+        Map<String, String> toTokenCustomValidation = tokenCustomValidation
 
-            if (invalid) {
-                log.info("Attempt to login with missing claim! [expecting '${expectedValue}' in JWT token claim '${expectedKey}']")
-                authenticationException("Please contact your system administrator for access")
+        // Look up corresponding mauro oauth config for provider
+        if (mauroConfiguration.oauths != null && !mauroConfiguration.oauths.isEmpty()) {
+            mauroConfiguration.oauths.forEach {MauroConfiguration.OAuthConfig oAuthConfig ->
+
+                final String configuredProviderName = oAuthConfig.oauthProvider
+
+                if (configuredProviderName == providerName) {
+                    log.debug("Using oauths configuration for ${providerName}")
+                    toCreateUser = oAuthConfig.createUser != null ? oAuthConfig.createUser : false
+                    toRequireVerifiedEmail = oAuthConfig.requireVerifiedEmail != null ? oAuthConfig.requireVerifiedEmail : true
+                    toTokenCustomValidation = oAuthConfig.tokenCustomValidation
+                    claims.put("app-login-success", oAuthConfig.appLoginSuccess)
+                }
             }
         }
 
-        CatalogueUser user = catalogueUserCacheableRepository.readByEmailAddress((String) claims.email) ?: createUser(claims)
+        // Entra does not provide email_verified
+        if (toRequireVerifiedEmail && !claims.email_verified) authenticationException("Attempt to login with unverified email address! [${claims.email}]")
+
+        if( toTokenCustomValidation !=null && !toTokenCustomValidation.isEmpty()) {
+            log.debug("Checking token custom claims")
+            toTokenCustomValidation.each {expectedKey, expectedValue ->
+                Object tokenValue = claims[expectedKey]
+
+                boolean invalid =
+                    tokenValue == null ||
+                    (tokenValue instanceof String && tokenValue != expectedValue) ||
+                    (tokenValue instanceof Collection<?> && !((Collection<?>) tokenValue).contains(expectedValue))
+
+                if (invalid) {
+                    log.info("Attempt to login with missing claim! [expecting '${expectedValue}' in JWT token claim '${expectedKey}']")
+                    authenticationException("Please contact your system administrator for access")
+                } else {
+                    log.debug("Found '${expectedValue}' in JWT token claim '${expectedKey}'")
+                }
+            }
+        }
+
+        CatalogueUser user = catalogueUserCacheableRepository.readByEmailAddress((String) claims.email) ?: toCreateUser ? createUser(claims) : null
         if (!user) authenticationException("User does not exist for $claims.email")
         claims.id = user.id
-        log.debug("claims: id: {}", user.id)
+        claims.forEach {String claim, Object claimValue ->
+            log.debug("claims: {}: {}", claim, claimValue)
+        }
         claims
     }
 
     CatalogueUser createUser(Map<String, Object> claims) {
-
-        if (createUser) {
-            log.debug("User email address not found, adding new Catalogue user for : {}", claims.email)
-            CatalogueUser newUser = new CatalogueUser().tap {
-                pending = false
-                disabled = false
-                creationMethod = 'OpenID-Connect'
-                tempPassword = null
-                password = null
-                firstName = claims.given_name
-                lastName = claims.family_name
-                emailAddress = claims.email
-                salt = SecureRandomStringGenerator.generateSalt()
-            }
-            return catalogueUserCacheableRepository.save(newUser)
+        log.debug("User email address not found, adding new Catalogue user for : {}", claims.email)
+        CatalogueUser newUser = new CatalogueUser().tap {
+            pending = false
+            disabled = false
+            creationMethod = 'OpenID-Connect'
+            tempPassword = null
+            password = null
+            firstName = claims.given_name
+            lastName = claims.family_name
+            emailAddress = claims.email
+            salt = SecureRandomStringGenerator.generateSalt()
         }
-        return null
+        return catalogueUserCacheableRepository.save(newUser)
     }
 
     static void authenticationException(String message) {

--- a/mauro-api/src/main/groovy/org/maurodata/security/authentication/MauroSessionLoginHandler.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/security/authentication/MauroSessionLoginHandler.groovy
@@ -76,12 +76,12 @@ class MauroSessionLoginHandler extends SessionLoginHandler {
 
             sessionStore.save(session)
                 .exceptionally(ex -> {
-                    log.error("Failed to save session", ex);
-                    return null;
+                    log.error("Failed to save session", ex)
+                    return null
                 })
 
             for (HttpSessionIdEncoder encoder : encoders) {
-                encoder.encodeId(request, defaultResponse, session);
+                encoder.encodeId(request, defaultResponse, session)
             }
         }
 
@@ -97,25 +97,36 @@ class MauroSessionLoginHandler extends SessionLoginHandler {
                 log.debug 'Successful login, returning Authentication'
                 return defaultResponse.body(catalogueUserCacheableRepository.readById((UUID) authentication.attributes.id))
             } else {
-                log.debug 'Successful login, redirecting to login success URI'
-                MutableHttpResponse<?> response = defaultResponse.status(HttpStatus.SEE_OTHER)
-                MutableHttpHeaders headers = response.headers as MutableHttpHeaders
-                URI redirectUri = loginSuccessUrl
+                String configuredAppLoginSuccessURL = authentication.attributes.get('app-login-success') as String
+                Optional<Cookie> cookieAppLoginSuccessURL = request.getCookies().findCookie(OAuthRedirectFilter.UI_REDIRECT_URL)
+
+                URI appLoginSuccess = null
                 try {
-                    Optional<Cookie> redirectCookie = request.getCookies().findCookie(OAuthRedirectFilter.UI_REDIRECT_URL)
-                    if (redirectCookie && redirectCookie.get()) {
-                        redirectUri = URI.create(redirectCookie.get().value)
-                    }
+                    appLoginSuccess =
+                        cookieAppLoginSuccessURL.present ? new URI(cookieAppLoginSuccessURL.get().value) :
+                        configuredAppLoginSuccessURL ? new URI(configuredAppLoginSuccessURL) :
+                        loginSuccessUrl
                 } catch (Exception e) {
-                    log.warn("Invalid value for Cookie '${OAuthRedirectFilter.UI_REDIRECT_URL}")
+                    if (cookieAppLoginSuccessURL.present) {
+                        log.warn("App login success redirect: Invalid value for Cookie '${OAuthRedirectFilter.UI_REDIRECT_URL}'")
+                    } else {
+                        log.warn("App login success redirect: Invalid value for Configured '${configuredAppLoginSuccessURL}'")
+                    }
                 }
-                headers.location(redirectUri)
-                response
+
+                if (appLoginSuccess) {
+                    log.debug 'Successful login, redirecting to login success URI'
+                    MutableHttpResponse<?> response = defaultResponse.status(HttpStatus.SEE_OTHER)
+                    MutableHttpHeaders headers = response.headers as MutableHttpHeaders
+                    headers.location(appLoginSuccess)
+                    return response
+                }
             }
-        } else {
-            defaultResponse
         }
+
+        defaultResponse
     }
+
 
     @Override
     MutableHttpResponse<?> loginFailed(AuthenticationResponse authenticationFailed, HttpRequest<?> request) {

--- a/mauro-api/src/main/groovy/org/maurodata/security/authentication/OAuthRedirectFilter.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/security/authentication/OAuthRedirectFilter.groovy
@@ -30,13 +30,15 @@ class OAuthRedirectFilter implements HttpServerFilter {
         String host = httpHostResolver.resolve(request)
         URI requestHostURI = new URI(host)
 
+        boolean secure = requestHostURI.scheme == "https"
+
         // Use Mono.from to turn publisher -> Mono, then map the response
         return Mono.from(chain.proceed(request))
-            .map { MutableHttpResponse<?> resp ->
-                if(redirectUri) {
+            .map {MutableHttpResponse<?> resp ->
+                if (redirectUri) {
                     Cookie cookie = Cookie.of(UI_REDIRECT_URL, redirectUri)
-                        .secure(requestHostURI.scheme == "https")
-                        .sameSite(SameSite.None)
+                        .secure(secure)
+                        .sameSite(secure ? SameSite.None : SameSite.Lax)
                         .httpOnly(true)
                         .path("/")
                         .maxAge(300)

--- a/mauro-api/src/main/resources/application.yml
+++ b/mauro-api/src/main/resources/application.yml
@@ -11,6 +11,10 @@ micronaut:
       max-file-size: 500mb
     cors:
       enabled: true
+    host-resolution:
+      protocol-header: X-Forwarded-Proto
+      host-header: Host
+      port-header: X-Forwarded-Port
   router:
     static-resources:
       default:

--- a/mauro-domain/src/main/groovy/org/maurodata/plugin/MauroPluginService.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/plugin/MauroPluginService.groovy
@@ -3,6 +3,7 @@ package org.maurodata.plugin
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.ApplicationContextBuilder
 import io.micronaut.context.BeanDefinitionRegistry
 import io.micronaut.context.RuntimeBeanDefinition
 import io.micronaut.context.annotation.Context
@@ -171,13 +172,23 @@ class MauroPluginService {
             apiClassLoader
         )
 
+        Map<String, Object> cfg = [
+            "micronaut.security.oauth2.enabled": false,
+            "micronaut.security.oauth2.clients": [:]
+        ] as Map<String, Object>
+
         ApplicationContext applicationContext = null
         try {
             classLoaders.add(pluginLoader)
 
-            applicationContext = ApplicationContext.run(
-                pluginLoader
-            ) as ApplicationContext
+            ApplicationContextBuilder applicationContextBuilder = ApplicationContext.builder()
+                .classLoader(pluginLoader)
+                .banner(false)
+                .properties(cfg)
+
+            applicationContext = applicationContextBuilder.build()
+            applicationContext.start()
+
         } catch(Throwable th) {
             log.error("** Failed to load plugin ${pluginLocation} **")
             classLoaders.remove(pluginLoader)


### PR DESCRIPTION
Collects properties per oauth entry:

oauths:
    -   app-label: Microsoft Azure
        app-image-url: .....png
        app-login-success: http://localhost:8080/redirects/open-id-connect-redirect.html
        oauth-provider: microsoft-azure
        create-user: true
        require-verified-email: false
    -   app-label: Keycloak
        app-login-success: http://localhost:8080/redirects/open-id-connect-redirect.html
        oauth-provider: keycloak
        create-user: true
        require-verified-email: false
        token-custom-validation:
            claim: value

oauth-provider and app-label are mandatory

An oauth-provider property matches up with an oauth client defined in micronaut.security.oauth2.clients

app-login-success is a fallback location to redirect to when login is successful and the redirect_url has not been given

create-user, require-verified-email, and token-custom-validation claims are applied per oauth-provider - it's best to have a one-to-one correspondence between an oauth entry and an oauth-provider

Login success redirect is: cookie, or else app-login-success fallback, or else mauro.oauth.login-success

OpenidProviderController uses either the mauro.oauth.* properties or else mauro.oauths list properties

OpenidProviderController creates the starting authorization-endpoint from the local configuration, the request, and the provider name. If the request comes via a proxy, and the proxy headers are set, it will construct the authorization-endpoint from the point of view of the requester

SameSite.None cookies are only sent over secure channels, use SameSite.Lax over http

MauroPluginService: prevents plugins revisiting oauth set-up when they are started