### PR TITLE
Fix issue with paginate and 'all' parameter

### DIFF
--- a/mauro-domain/src/main/groovy/org/maurodata/web/ListResponse.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/web/ListResponse.groovy
@@ -130,7 +130,7 @@ class ListResponse<T> {
         }
 
         // Paginate
-        if (params.all.equalsIgnoreCase(Boolean.TRUE.toString())) {
+        if (params.all && params.all.equalsIgnoreCase(Boolean.TRUE.toString())) {
             return sorted
         } else {
             int start = Math.max(0, params.offset ?: 0)

--- a/mauro-domain/src/main/groovy/org/maurodata/web/PaginationParams.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/web/PaginationParams.groovy
@@ -33,7 +33,7 @@ class PaginationParams {
     String definition = null
 
     @Nullable
-    String all = false
+    String all = "false"
 
     @Nullable
     String domainType = null


### PR DESCRIPTION
Fixes the error reported:
```
Server Error",
  "error": {
    "message": "Internal Server Error",
    "_links": {
      "self": {
        "href": "/api/catalogueUsers?max=50",
        "templated": false
      }
    },
    "_embedded": {
      "errors": [
        {
          "message": "Internal Server Error: Cannot invoke \"String.equalsIgnoreCase(String)\" because the return value of \"org.maurodata.web.PaginationParams.getAll()\" is null"
        }
      ]
    }
  }
}
```