### PR TITLE
Ensure sessions make it into the session store and back

### DIFF
--- a/mauro-api/src/main/groovy/org/maurodata/controller/security/session/SessionConveyingFilter.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/controller/security/session/SessionConveyingFilter.groovy
@@ -1,0 +1,87 @@
+package org.maurodata.controller.security.session
+
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import io.micronaut.core.async.publisher.Publishers
+import io.micronaut.core.util.CollectionUtils
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MutableHttpResponse
+import io.micronaut.http.annotation.Filter
+import io.micronaut.http.filter.HttpServerFilter
+import io.micronaut.http.filter.ServerFilterChain
+import io.micronaut.http.filter.ServerFilterPhase
+import io.micronaut.session.Session
+import io.micronaut.session.SessionStore
+import io.micronaut.session.http.HttpSessionConfiguration
+import io.micronaut.session.http.HttpSessionFilter
+import io.micronaut.session.http.HttpSessionIdResolver
+import io.micronaut.session.http.SessionForRequest
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Flux
+
+@CompileStatic
+@Filter("/**")
+@Singleton
+@Slf4j
+class SessionConveyingFilter implements HttpServerFilter {
+
+    public static final Integer ORDER = ServerFilterPhase.SESSION.order()+ 10
+
+    @Inject
+    private final SessionStore<Session> sessionStore
+
+    @Inject
+    private final HttpSessionConfiguration configuration
+
+    @Inject
+    private final HttpSessionIdResolver[] resolvers
+
+    @Override
+    int getOrder() {
+        return ORDER
+    }
+
+    @Inject
+        SessionConveyingFilter(SessionStore<Session> sessionStore,HttpSessionConfiguration configuration, HttpSessionIdResolver[] resolvers){
+        this.sessionStore = sessionStore
+        this.configuration = configuration
+        this.resolvers = resolvers
+    }
+
+    @Override
+    Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request,
+                                               ServerFilterChain chain) {
+        request.setAttribute(SessionConveyingFilter.class.getName(), true)
+
+        try {
+            request.getCookies().findCookie(configuration.getCookieName()).ifPresent(cookie -> {
+                // String sessionId = cookie.getValue()
+
+                Session sessionIsThere = SessionForRequest.find(request).orElse(null)
+                if (!sessionIsThere) {
+                    for (HttpSessionIdResolver resolver : resolvers) {
+                        List<String> ids = resolver.resolveIds(request)
+                        if (CollectionUtils.isNotEmpty(ids)) {
+                            String sessionId = ids.get(0)
+                            // Not retrievable, pull the session directly from the store
+                            sessionStore.findSession(sessionId).thenAccept(optionalSession -> {
+                                if (optionalSession.isPresent()) {
+                                    Session session = optionalSession.get()
+                                    request.getAttributes().put(
+                                        HttpSessionFilter.SESSION_ATTRIBUTE, session
+                                    )
+                                }
+                            })
+                        }
+                    }
+                }
+            })
+        } catch (Throwable th){
+            th.printStackTrace()
+        }
+
+        return chain.proceed(request)
+    }
+}

--- a/mauro-api/src/main/groovy/org/maurodata/controller/security/tracking/AccessTrackingFilter.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/controller/security/tracking/AccessTrackingFilter.groovy
@@ -9,6 +9,7 @@ import io.micronaut.http.MutableHttpResponse
 import io.micronaut.http.annotation.Filter
 import io.micronaut.http.filter.HttpServerFilter
 import io.micronaut.http.filter.ServerFilterChain
+import io.micronaut.http.filter.ServerFilterPhase
 import io.micronaut.security.utils.SecurityService
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
@@ -20,6 +21,8 @@ import reactor.core.publisher.Mono
 @Singleton
 class AccessTrackingFilter implements HttpServerFilter {
 
+    public static final Integer ORDER = ServerFilterPhase.SESSION.order() + 11
+
     private final SessionTracker tracker
     private final SecurityService securityService
 
@@ -27,6 +30,11 @@ class AccessTrackingFilter implements HttpServerFilter {
     AccessTrackingFilter(SessionTracker tracker, @Nullable SecurityService securityService) {
         this.tracker = tracker
         this.securityService = securityService
+    }
+
+    @Override
+    int getOrder() {
+        return ORDER
     }
 
     @Override

--- a/mauro-api/src/main/groovy/org/maurodata/security/authentication/MauroSessionLoginHandler.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/security/authentication/MauroSessionLoginHandler.groovy
@@ -6,7 +6,10 @@ import io.micronaut.context.annotation.Replaces
 import io.micronaut.context.annotation.Value
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.http.*
+import io.micronaut.http.context.ServerContextPathProvider
 import io.micronaut.http.cookie.Cookie
+import io.micronaut.http.server.util.HttpHostResolver
+import io.micronaut.http.uri.UriBuilder
 import io.micronaut.security.authentication.Authentication
 import io.micronaut.security.authentication.AuthenticationResponse
 import io.micronaut.security.config.RedirectConfiguration
@@ -17,6 +20,9 @@ import io.micronaut.security.session.SessionLoginHandler
 import io.micronaut.security.session.SessionPopulator
 import io.micronaut.session.Session
 import io.micronaut.session.SessionStore
+import io.micronaut.session.http.HttpSessionConfiguration
+import io.micronaut.session.http.HttpSessionIdEncoder
+import io.micronaut.session.http.SessionForRequest
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
 import org.maurodata.persistence.cache.ItemCacheableRepository.CatalogueUserCacheableRepository
@@ -40,6 +46,18 @@ class MauroSessionLoginHandler extends SessionLoginHandler {
     @Value('${mauro.oauth.login-success:/}')
     URI loginSuccessUrl
 
+    @Inject
+    ServerContextPathProvider serverContextPathProvider
+
+    @Inject
+    HttpHostResolver httpHostResolver
+
+    @Inject
+    HttpSessionConfiguration configuration
+
+    @Inject
+    HttpSessionIdEncoder[] encoders
+
     MauroSessionLoginHandler(RedirectConfiguration redirectConfiguration, SessionStore<Session> sessionStore,
                              @Nullable PriorToLoginPersistence<HttpRequest<?>, MutableHttpResponse<?>> priorToLoginPersistence, RedirectService redirectService,
                              List<SessionPopulator<HttpRequest<?>>> sessionPopulators) {
@@ -50,18 +68,42 @@ class MauroSessionLoginHandler extends SessionLoginHandler {
     MutableHttpResponse<?> loginSuccess(Authentication authentication, HttpRequest<?> request) {
         log.debug 'At MauroSessionLoginHandler loginSuccess!'
         MutableHttpResponse defaultResponse = super.loginSuccess(authentication, request)
+
+        Session session = SessionForRequest.find(request).get()
+
+        // Create set-cookie, save the session in the session store
+        if (session != null) {
+
+            sessionStore.save(session)
+                .exceptionally(ex -> {
+                    log.error("Failed to save session", ex);
+                    return null;
+                })
+
+            for (HttpSessionIdEncoder encoder : encoders) {
+                encoder.encodeId(request, defaultResponse, session);
+            }
+        }
+
         if (defaultResponse.status == HttpStatus.OK) {
-            if (request.path == loginControllerConfigurationProperties.path) {
+            String contextPath = serverContextPathProvider.getContextPath() ?: ""
+
+            String loginPath = UriBuilder.of("/")
+                .path(contextPath)
+                .path(loginControllerConfigurationProperties.path)
+                .build().toString()
+
+            if (request.path == loginPath) {
                 log.debug 'Successful login, returning Authentication'
-                return HttpResponse.ok(catalogueUserCacheableRepository.readById((UUID) authentication.attributes.id))
+                return defaultResponse.body(catalogueUserCacheableRepository.readById((UUID) authentication.attributes.id))
             } else {
                 log.debug 'Successful login, redirecting to login success URI'
-                MutableHttpResponse<?> response = HttpResponse.status(HttpStatus.SEE_OTHER)
+                MutableHttpResponse<?> response = defaultResponse.status(HttpStatus.SEE_OTHER)
                 MutableHttpHeaders headers = response.headers as MutableHttpHeaders
                 URI redirectUri = loginSuccessUrl
                 try {
                     Optional<Cookie> redirectCookie = request.getCookies().findCookie(OAuthRedirectFilter.UI_REDIRECT_URL)
-                    if(redirectCookie && redirectCookie.get()) {
+                    if (redirectCookie && redirectCookie.get()) {
                         redirectUri = URI.create(redirectCookie.get().value)
                     }
                 } catch (Exception e) {


### PR DESCRIPTION
When micronaut.server.context-path has been set, for reasons unknown, the session information isn't stored and then retrieved from the session store.

This means setting the cookie information in MauroSessionLoginHandler, and retrieving it again in SessionConveyingFilter. Encoders and decoders are used on the session value (basically base64, but the code mimics what Micronaut's HttpSessionFilter does)