### PR TITLE
Download plugins from repository

### DIFF
--- a/mauro-api/docker/all/micronaut/micronaut-startup.sh
+++ b/mauro-api/docker/all/micronaut/micronaut-startup.sh
@@ -1,10 +1,56 @@
 #!/usr/bin/env bash
 set -e
 
+ADD_PLUGINS="true"
+
+if [ "${PLUGINS_IS_MOUNTED}" == "true" ];
+then
+  if [ "$(ls -1 /home/app/plugins)" != "" ];
+  then
+    echo "There are persisted plugins."
+    ADD_PLUGINS="false"
+  fi
+fi
+
+if [ -e /opt/init/micronaut ];
+then
+  mkdir -p /home/app/plugins || true
+  pushd /opt/init/micronaut
+
+        shopt -s nullglob
+        for f in *
+        do
+          case "${f}" in
+            *.sh)
+                echo "Running ${f}"
+                if [ -x "${f}" ];
+                then
+                    /bin/bash "${f}"
+                else
+                    . "${f}"
+                fi
+              ;;
+            *.jar)
+              if [ "${ADD_PLUGINS}" == "true" ];
+              then
+                  echo "Adding ${f} as plugin"
+                  cp -pf ${f} /home/app/plugins/.
+              fi
+              ;;
+            *)
+                  echo "Copying ${f} to micronaut resources"
+                  cp "${f}" /home/app/resources/.
+              ;;
+          esac
+        done
+        shopt -u nullglob
+  popd
+else
+      echo "No /opt/init/micronaut for *.sh *.yml *.xml *.properties etc - skipping"
+fi
+
 # Figure out the java options
 
-if [ "${PG_SHARING_HOST}" == "true" ];
-then
 declare -A java_opts=(
   [4]="-server -Xms614M -Xmx2457M -XX:MaxNewSize=1126M -XX:NewSize=204M -XX:MetaspaceSize=256M -XX:MaxMetaspaceSize=784M -XX:NewRatio=2 -XX:SurvivorRatio=2 -XX:TargetSurvivorRatio=80 -XX:+UseParallelGC -XX:+AggressiveHeap -XX:GCTimeRatio=19 -XX:MaxGCPauseMillis=3500 -XX:InitialCodeCacheSize=48M -XX:ReservedCodeCacheSize=240M"
   [8]="-server -Xms1843M -Xmx7372M -XX:MaxNewSize=3379M -XX:NewSize=614M -XX:MetaspaceSize=768M -XX:MaxMetaspaceSize=2764M -XX:NewRatio=2 -XX:SurvivorRatio=2 -XX:TargetSurvivorRatio=80 -XX:+UseParallelGC -XX:+AggressiveHeap -XX:GCTimeRatio=19 -XX:MaxGCPauseMillis=3500 -XX:InitialCodeCacheSize=48M -XX:ReservedCodeCacheSize=307M"
@@ -56,5 +102,5 @@ echo "Starting Micronaut..."
 cd /home/app
 # Give the directory and contents to the micronaut user
 chown -R micronaut:micronaut /home/app
-echo ${JAVA_BIN} "${JAVA_OPTS}" -cp "/home/app/application.jar" "${APPLICATION_MAIN_CLASS}"
-gosu micronaut ${JAVA_BIN} ${JAVA_OPTS} -cp /home/app/application.jar "${APPLICATION_MAIN_CLASS}"
+echo ${JAVA_BIN} "${JAVA_OPTS}" -cp "/home/app/application.jar" -DPLUGINS_IS_MOUNTED=${PLUGINS_IS_MOUNTED} "${APPLICATION_MAIN_CLASS}"
+gosu micronaut ${JAVA_BIN} ${JAVA_OPTS} -cp /home/app/application.jar -DPLUGINS_IS_MOUNTED=${PLUGINS_IS_MOUNTED} "${APPLICATION_MAIN_CLASS}"

--- a/mauro-api/docker/all/micronaut/micronaut-startup.sh
+++ b/mauro-api/docker/all/micronaut/micronaut-startup.sh
@@ -50,7 +50,8 @@ else
 fi
 
 # Figure out the java options
-
+if [ "${PG_SHARING_HOST}" == "true" ];
+then
 declare -A java_opts=(
   [4]="-server -Xms614M -Xmx2457M -XX:MaxNewSize=1126M -XX:NewSize=204M -XX:MetaspaceSize=256M -XX:MaxMetaspaceSize=784M -XX:NewRatio=2 -XX:SurvivorRatio=2 -XX:TargetSurvivorRatio=80 -XX:+UseParallelGC -XX:+AggressiveHeap -XX:GCTimeRatio=19 -XX:MaxGCPauseMillis=3500 -XX:InitialCodeCacheSize=48M -XX:ReservedCodeCacheSize=240M"
   [8]="-server -Xms1843M -Xmx7372M -XX:MaxNewSize=3379M -XX:NewSize=614M -XX:MetaspaceSize=768M -XX:MaxMetaspaceSize=2764M -XX:NewRatio=2 -XX:SurvivorRatio=2 -XX:TargetSurvivorRatio=80 -XX:+UseParallelGC -XX:+AggressiveHeap -XX:GCTimeRatio=19 -XX:MaxGCPauseMillis=3500 -XX:InitialCodeCacheSize=48M -XX:ReservedCodeCacheSize=307M"

--- a/mauro-api/docker/all/startup/docker-environment.sh
+++ b/mauro-api/docker/all/startup/docker-environment.sh
@@ -35,3 +35,17 @@ export DOCKER_BRIDGE_ADDRESSES="host.docker.internal ${DOCKER_CONTAINER_NETWORK_
 
 echo "Docker internal addresses ${DOCKER_LOCAL_ADDRESSES}"
 echo "Docker bridge addresses ${DOCKER_BRIDGE_ADDRESSES}"
+
+if [ -e /home/app/plugins ];
+then
+  MOUNTED_PLUGINS_AT=$(df -T "/home/app/plugins" | awk 'NR==2 {print $NF}')
+
+  if [ "${MOUNTED_PLUGINS_AT}" = "/" ];
+  then
+    export PLUGINS_IS_MOUNTED="false"
+  else
+    export PLUGINS_IS_MOUNTED="true"
+  fi
+else
+    export PLUGINS_IS_MOUNTED="false"
+fi

--- a/mauro-api/docker/noDB/micronaut/micronaut-startup.sh
+++ b/mauro-api/docker/noDB/micronaut/micronaut-startup.sh
@@ -1,9 +1,20 @@
 #!/usr/bin/env bash
 set -e
 
+ADD_PLUGINS="true"
+
+if [ "${PLUGINS_IS_MOUNTED}" == "true" ];
+then
+  if [ "$(ls -1 /home/app/plugins)" != "" ];
+  then
+    echo "There are persisted plugins."
+    ADD_PLUGINS="false"
+  fi
+fi
+
 if [ -e /opt/init/micronaut ];
 then
-  mkdir -p /home/app/plugins
+  mkdir -p /home/app/plugins || true
   pushd /opt/init/micronaut
 
         shopt -s nullglob
@@ -20,8 +31,11 @@ then
                 fi
               ;;
             *.jar)
-              echo "Adding ${f} as plugin"
-              cp -pf ${f} /home/app/plugins/.
+              if [ "${ADD_PLUGINS}" == "true" ];
+              then
+                  echo "Adding ${f} as plugin"
+                  cp -pf ${f} /home/app/plugins/.
+              fi
               ;;
             *)
                   echo "Copying ${f} to micronaut resources"
@@ -74,5 +88,5 @@ echo "Starting Micronaut..."
 cd /home/app
 # Give the directory and contents to the micronaut user
 chown -R micronaut:micronaut /home/app
-echo ${JAVA_BIN} "${JAVA_OPTS}" -cp "/home/app/application.jar" "${APPLICATION_MAIN_CLASS}"
-gosu micronaut ${JAVA_BIN} ${JAVA_OPTS} -cp /home/app/application.jar "${APPLICATION_MAIN_CLASS}"
+echo ${JAVA_BIN} "${JAVA_OPTS}" -cp "/home/app/application.jar" -DPLUGINS_IS_MOUNTED=${PLUGINS_IS_MOUNTED} "${APPLICATION_MAIN_CLASS}"
+gosu micronaut ${JAVA_BIN} ${JAVA_OPTS} -cp /home/app/application.jar -DPLUGINS_IS_MOUNTED=${PLUGINS_IS_MOUNTED} "${APPLICATION_MAIN_CLASS}"

--- a/mauro-api/docker/noDB/startup/docker-environment.sh
+++ b/mauro-api/docker/noDB/startup/docker-environment.sh
@@ -27,3 +27,17 @@ echo "Detected ${CPU_COUNT} cores"
 export DOCKER_SUBNET="$(ip -o -4 addr show 2>/dev/null | awk '/scope global/ {split($4,a,"/");split(a[1],b,".");printf "%d.%d.%d.0/%s\n",b[1],b[2],b[3],a[2];exit}')"
 
 echo "Docker subnet ${DOCKER_SUBNET}"
+
+if [ -e /home/app/plugins ];
+then
+  MOUNTED_PLUGINS_AT=$(df -T "/home/app/plugins" | awk 'NR==2 {print $NF}')
+
+  if [ "${MOUNTED_PLUGINS_AT}" = "/" ];
+  then
+    export PLUGINS_IS_MOUNTED="false"
+  else
+    export PLUGINS_IS_MOUNTED="true"
+  fi
+else
+    export PLUGINS_IS_MOUNTED="false"
+fi

--- a/mauro-api/src/main/groovy/org/maurodata/controller/MauroApplicationContextConfigurer.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/controller/MauroApplicationContextConfigurer.groovy
@@ -2,6 +2,7 @@ package org.maurodata.controller
 
 import io.micronaut.context.annotation.Property
 import org.maurodata.plugin.MauroPlugin
+import org.maurodata.plugin.MauroPluginUtil
 import org.maurodata.profile.Profile
 
 import groovy.transform.CompileStatic
@@ -65,11 +66,11 @@ class MauroApplicationContextConfigurer implements ApplicationContextConfigurer 
 
             if (Files.isDirectory(baseDirPath)) {
                 // Application is in an IDE
-                pluginsDirPath = findProjectRoot(baseDirPath)?.resolve("plugins")
+                pluginsDirPath = MauroPluginUtil.findProjectRoot(baseDirPath)?.resolve("plugins")
                 log.debug("Application IDE Plugin base directory ${baseDirPath}")
             } else {
                 // Application is in a packaged jar
-                pluginsDirPath = findAppRoot(baseDirPath.getParent())?.resolve("plugins")
+                pluginsDirPath = MauroPluginUtil.findAppRoot(baseDirPath.getParent())?.resolve("plugins")
                 log.debug("Application Plugin base directory ${baseDirPath}")
             }
 

--- a/mauro-api/src/main/groovy/org/maurodata/controller/MauroApplicationContextConfigurer.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/controller/MauroApplicationContextConfigurer.groovy
@@ -84,31 +84,6 @@ class MauroApplicationContextConfigurer implements ApplicationContextConfigurer 
         }
     }
 
-    private static Path findProjectRoot(final Path start) {
-        Path current = start
-        while (current != null) {
-            if (Files.exists(current.resolve("build.gradle")) ||
-                Files.exists(current.resolve("pom.xml"))) {
-                return current
-            }
-            current = current.getParent()
-        }
-        return null
-    }
-
-    private static Path findAppRoot(final Path start) {
-        Path current = start
-        while (current != null) {
-            if (Files.exists(current.resolve("resources")) ||
-                Files.exists(current.resolve("plugins"))
-            ) {
-                return current
-            }
-            current = current.getParent()
-        }
-        return null
-    }
-
     private void loadPlugins(final Path pluginsDirPath, final ApplicationContext applicationContext) {
         log.debug("Loading plugins")
         try (DirectoryStream<Path> files = Files.newDirectoryStream(pluginsDirPath)) {
@@ -183,12 +158,12 @@ class MauroApplicationContextConfigurer implements ApplicationContextConfigurer 
 
                 ((BeanDefinitionRegistry) applicationContext).registerBeanDefinition(beanDefinition as RuntimeBeanDefinition<Object>)
 
-                if(Profile.class.isAssignableFrom(beanType)) {
+                if (Profile.class.isAssignableFrom(beanType)) {
                     log.info("Profile: ${ref}")
-                } else if(MauroPlugin.class.isAssignableFrom(beanType)) {
+                } else if (MauroPlugin.class.isAssignableFrom(beanType)) {
                     log.info("MauroPlugin: ${ref}")
                 } else {
-                    if (ref.hasAnnotation(Controller) ) {
+                    if (ref.hasAnnotation(Controller)) {
                         log.info("Controller: ${ref}")
                         Method[] methods = beanType.getMethods()
                         methods.each {Method method ->

--- a/mauro-api/src/main/groovy/org/maurodata/controller/admin/AdminController.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/controller/admin/AdminController.groovy
@@ -4,6 +4,7 @@ import org.maurodata.api.Paths
 import org.maurodata.api.admin.AdminApi
 import org.maurodata.audit.Audit
 import org.maurodata.plugin.MauroPluginDTO
+import org.maurodata.service.plugin.PluginRepositoryService
 
 import groovy.transform.CompileStatic
 import io.micronaut.http.HttpStatus
@@ -14,6 +15,7 @@ import io.micronaut.http.annotation.Post
 import io.micronaut.http.exceptions.HttpStatusException
 import io.micronaut.runtime.EmbeddedApplication
 import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
 import io.micronaut.security.annotation.Secured
 import io.micronaut.security.rules.SecurityRule
 import jakarta.inject.Inject
@@ -22,7 +24,6 @@ import org.maurodata.domain.security.CatalogueUser
 import org.maurodata.persistence.security.EmailRepository
 import org.maurodata.plugin.MauroPluginService
 import org.maurodata.plugin.exporter.ModelExporterPlugin
-import org.maurodata.plugin.exporter.ModelItemExporterPlugin
 import org.maurodata.plugin.importer.ImporterPlugin
 import org.maurodata.security.AccessControlService
 import org.maurodata.plugin.EmailPlugin
@@ -46,6 +47,9 @@ class AdminController implements AdminApi {
 
     @Inject
     EmailService emailService
+
+    @Inject
+    PluginRepositoryService service
 
     private final EmailRepository emailRepository
 
@@ -96,6 +100,22 @@ class AdminController implements AdminApi {
     @Get(Paths.ADMIN_DATALOADERS_LIST)
     List<MauroPluginDTO> dataLoaders() {
         []
+    }
+
+    @Audit
+    @ExecuteOn(TaskExecutors.BLOCKING)
+    @Get(Paths.ADMIN_AVAILABLE_PROVIDERS_LIST)
+    List<Map<String, String>> available() {
+        accessControlService.checkAdministrator()
+        service.listAvailablePlugins()
+    }
+
+    @Audit
+    @ExecuteOn(TaskExecutors.BLOCKING)
+    @Post(Paths.ADMIN_INSTALL_PROVIDER)
+    Map<String, Object> installPlugin(String plugin) {
+        accessControlService.checkAdministrator()
+        return service.installPlugin(plugin)
     }
 
     /**

--- a/mauro-api/src/main/groovy/org/maurodata/service/plugin/PluginRepositoryService.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/service/plugin/PluginRepositoryService.groovy
@@ -1,0 +1,317 @@
+package org.maurodata.service.plugin
+
+import org.maurodata.plugin.MauroPluginUtil
+
+import groovy.json.JsonSlurper
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import groovy.xml.XmlSlurper
+import groovy.xml.slurpersupport.GPathResult
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.exceptions.HttpStatusException
+import jakarta.inject.Singleton
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.util.regex.Pattern
+
+@CompileStatic
+@Singleton
+@Slf4j
+class PluginRepositoryService {
+
+    private static final String REPO_BASE = "https://mauro-repository.com"
+    private static final String PLUGIN_PATH = "/libs-snapshot-local/org/maurodata/plugins/"
+    private static final String API_BASE = "${REPO_BASE}/api/maven/details${PLUGIN_PATH}"
+
+    private final HttpClient httpClient
+
+    PluginRepositoryService(@Client("/") HttpClient httpClient) {
+        this.httpClient = httpClient
+    }
+
+    List<Map<String, String>> listAvailablePlugins() {
+
+        List<String> plugins = getPluginDirectories()
+
+        plugins.collect {plugin ->
+            String version = getLatestVersion(plugin)
+            if (!version) return null
+
+            String[] jarUrl = resolveJarUrl(plugin, version)
+            if (!jarUrl) return null
+
+            [
+                plugin : plugin,
+                version: version,
+                url    : jarUrl[0]
+            ] as Map<String, String>
+        }.findAll {it != null}
+    }
+
+    private List<String> getPluginDirectories() {
+
+        String json = httpClient.toBlocking()
+            .retrieve(API_BASE)
+
+        JsonSlurper slurper = new JsonSlurper()
+
+        Map<String, Object> parsed =
+            (Map<String, Object>) slurper.parseText(json)
+
+        List<Map<String, Object>> files =
+            (List<Map<String, Object>>) parsed.get("files")
+
+        List<String> directories = new ArrayList<>()
+
+        for (Map<String, Object> file : files) {
+
+            Object type = file.get("type")
+            Object name = file.get("name")
+
+            if ("DIRECTORY".equals(type) && name instanceof String) {
+                directories.add((String) name)
+            }
+        }
+
+        return directories
+    }
+
+    private String getLatestVersion(String plugin) {
+        String metadataUrl = "${REPO_BASE}${PLUGIN_PATH}${plugin}/maven-metadata.xml"
+
+        try {
+            String xml = httpClient.toBlocking().retrieve(metadataUrl)
+
+            XmlSlurper slurper = new XmlSlurper()
+            GPathResult metadata = slurper.parseText(xml)
+
+            GPathResult versioning = metadata.getProperty("versioning") as GPathResult
+            GPathResult latest = versioning.getProperty("latest") as GPathResult
+
+            return latest.text()
+        }
+        catch (Exception ignored) {
+            return null
+        }
+    }
+
+    private String[] resolveJarUrl(String plugin, String version) {
+
+        String resolvedVersion = version
+
+        if (version.endsWith("SNAPSHOT")) {
+            resolvedVersion = resolveSnapshotVersion(plugin, version)
+            if (resolvedVersion == null) return null
+        }
+
+        String moduleFile = resolveModuleFilename(plugin, version, resolvedVersion)
+        if (moduleFile == null) return null
+
+        return selectJarFromModule(plugin, version, resolvedVersion, moduleFile)
+    }
+
+    private String resolveSnapshotVersion(String plugin, String version) {
+
+        String metadataUrl =
+            "${REPO_BASE}${PLUGIN_PATH}${plugin}/${version}/maven-metadata.xml"
+
+        try {
+            String xml = httpClient.toBlocking().retrieve(metadataUrl)
+            XmlSlurper slurper = new XmlSlurper()
+            GPathResult metadata = slurper.parseText(xml)
+
+            GPathResult versioning =
+                (GPathResult) metadata.getProperty("versioning")
+
+            GPathResult snapshotVersions =
+                (GPathResult) versioning.getProperty("snapshotVersions")
+
+            GPathResult snapshotVersionList =
+                (GPathResult) snapshotVersions.getProperty("snapshotVersion")
+
+            for (Object obj : snapshotVersionList) {
+                GPathResult entry = (GPathResult) obj
+
+                GPathResult extensionResult = entry.getProperty("extension") as GPathResult
+                String extension = extensionResult.text()
+
+                if ("jar".equals(extension)) {
+
+                    GPathResult valueResult = entry.getProperty("value") as GPathResult
+                    return valueResult.text()
+                }
+            }
+        }
+        catch (Exception ignored) {}
+
+        return null
+    }
+
+    private static String resolveModuleFilename(String plugin,
+                                                String originalVersion,
+                                                String resolvedVersion) {
+
+        if (!originalVersion.endsWith("SNAPSHOT")) {
+            return "${plugin}-${originalVersion}.module"
+        }
+
+        return "${plugin}-${resolvedVersion}.module"
+    }
+
+    private String[] selectJarFromModule(String plugin,
+                                         String originalVersion,
+                                         String resolvedVersion,
+                                         String moduleFile) {
+
+        String moduleUrl =
+            "${REPO_BASE}${PLUGIN_PATH}${plugin}/${originalVersion}/${moduleFile}"
+
+        try {
+            String moduleJson = httpClient.toBlocking().retrieve(moduleUrl)
+
+            JsonSlurper slurper = new JsonSlurper()
+            Map<String, Object> parsed =
+                (Map<String, Object>) slurper.parseText(moduleJson)
+
+            List<Map<String, Object>> variants =
+                (List<Map<String, Object>>) parsed.get("variants")
+
+            Map<String, Object> selectedVariant = null
+
+            for (String variantName :
+                ["shadowRuntimeElements", "runtimeElements", "apiElements"]) {
+
+                for (Map<String, Object> variant : variants) {
+                    if (variantName.equals(variant.get("name"))) {
+                        selectedVariant = variant
+                        break
+                    }
+                }
+                if (selectedVariant != null) break
+            }
+
+            if (selectedVariant == null) return null
+
+            List<Map<String, Object>> files =
+                (List<Map<String, Object>>) selectedVariant.get("files")
+
+            for (Map<String, Object> file : files) {
+
+                Object nameObj = file.get("name")
+                Object urlObj = file.get("url")
+
+                if (nameObj instanceof String &&
+                    urlObj instanceof String &&
+                    ((String) nameObj).endsWith(".jar")) {
+
+                    String fileName
+                    if (originalVersion.endsWith("-SNAPSHOT")) {
+                        String baseVersion = originalVersion.replace("-SNAPSHOT", "")
+                        String timestampSuffix = resolvedVersion.replaceFirst(/^${baseVersion}-/, "")
+                        fileName = (urlObj as String).replaceFirst(/-SNAPSHOT/, "-${timestampSuffix}")
+                    } else {
+                        fileName = urlObj as String
+                    }
+
+
+                    return [
+                        "${REPO_BASE}${PLUGIN_PATH}${plugin}/${originalVersion}/${fileName}",
+                        "${REPO_BASE}${PLUGIN_PATH}${plugin}/${originalVersion}/${urlObj}",
+                        plugin
+                    ] as String[]
+                }
+            }
+        }
+        catch (Exception ignored) {}
+
+        return null
+    }
+
+    Map<String, Object> installPlugin(String plugin) {
+        String version = getLatestVersion(plugin)
+        if (!version) {
+            throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, 'Plugin not found: ' + plugin)
+        }
+
+        String[] jarUrl = resolveJarUrl(plugin, version)
+        if (!jarUrl) {
+            throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, 'Could not resolve plugin to a file: ' + plugin)
+        }
+
+        final Path pluginsDirPath = MauroPluginUtil.pluginsDirPath
+
+        if (pluginsDirPath == null) {
+            throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, 'Missing plugins directory')
+        }
+
+        if (!Files.exists(pluginsDirPath)) {
+            throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, 'Missing plugins directory: ' + pluginsDirPath.toString())
+        }
+
+        final String PLUGINS_IS_MOUNTED = System.getenv("PLUGINS_IS_MOUNTED")
+        if (PLUGINS_IS_MOUNTED != null && PLUGINS_IS_MOUNTED == 'false') {
+            throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, 'Plugins directory is not using persistent storage')
+        }
+
+        log.debug("Download ${jarUrl[0]} into ${pluginsDirPath} as ${jarUrl[1]}, removing any other ${jarUrl[2]}")
+        return downloadPluginJar(jarUrl, pluginsDirPath)
+    }
+
+    private static Map<String, Object> downloadPluginJar(String[] jarUrl, Path dirPath) {
+        URL downloadUrl = new URL(jarUrl[0])
+        URL saveUrl = new URL(jarUrl[1])
+        String plugin = jarUrl[2]
+
+        String path = saveUrl.getPath()
+        int lastSlash = path.lastIndexOf('/')
+        if (lastSlash == -1) {
+            throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, 'Malformed URL. Missing path: ' + saveUrl.toString())
+        }
+
+        String fileName = path.substring(lastSlash + 1)
+        Path filePath = dirPath.resolve(fileName)
+
+        downloadUrl.withInputStream {input ->
+            Files.copy(input, filePath, StandardCopyOption.REPLACE_EXISTING)
+        }
+
+        // Find all plugin files with the same naming
+
+        Pattern pattern = Pattern.compile(
+            '^' + Pattern.quote(plugin) + '-\\d+\\.\\d+\\.\\d+.*\\.jar$'
+        )
+
+        List<File> matches = new ArrayList<>()
+
+        File[] files = dirPath.toFile().listFiles()
+
+        if (files != null && files.length > 0) {
+            for (File file : files) {
+                if (file.isFile()) {
+                    String name = file.getName()
+                    if (pattern.matcher(name).matches() && !name.equalsIgnoreCase(fileName)) {
+                        matches.add(file)
+                    }
+                }
+            }
+        }
+
+        matches.forEach {File toDelete ->
+            boolean deleted = toDelete.delete()
+            if (!deleted) {
+                throw new IOException("Failed to remove plugin file: " + toDelete.getName())
+            }
+        }
+
+        return [
+            installed: plugin,
+            from     : downloadUrl.toString(),
+            as       : fileName,
+            removed  : matches.collect {File removed -> removed.getName()} as List<String>
+        ] as Map<String, Object>
+    }
+}

--- a/mauro-client/src/main/groovy/org/maurodata/api/Paths.groovy
+++ b/mauro-client/src/main/groovy/org/maurodata/api/Paths.groovy
@@ -18,6 +18,8 @@ interface Paths {
     String ADMIN_EMAILS = '/api/admin/emails'
     String ADMIN_EMAIL_RETRY = '/api/admin/emails/{emailId}/retry'
     String ADMIN_SHUTDOWN = '/api/admin/shutdown'
+    String ADMIN_AVAILABLE_PROVIDERS_LIST = '/api/admin/providers/available'
+    String ADMIN_INSTALL_PROVIDER = '/api/admin/provider/install/{plugin}'
 
     /*
     * ClassificationSchemeApi

--- a/mauro-client/src/main/groovy/org/maurodata/api/admin/AdminApi.groovy
+++ b/mauro-client/src/main/groovy/org/maurodata/api/admin/AdminApi.groovy
@@ -59,4 +59,10 @@ interface AdminApi {
 
     @Post(Paths.ADMIN_SHUTDOWN)
     Boolean shutDown()
+
+    @Get(Paths.ADMIN_AVAILABLE_PROVIDERS_LIST)
+    List<Map> available()
+
+    @Post(Paths.ADMIN_INSTALL_PROVIDER)
+    Map<String, Object> installPlugin(String plugin)
 }

--- a/mauro-domain/src/main/groovy/org/maurodata/plugin/MauroPluginUtil.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/plugin/MauroPluginUtil.groovy
@@ -1,0 +1,57 @@
+package org.maurodata.plugin
+
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+@CompileStatic
+@Slf4j
+class MauroPluginUtil {
+
+    private static Path findProjectRoot(final Path start) {
+        Path current = start
+        while (current != null) {
+            if (Files.exists(current.resolve("build.gradle")) ||
+                Files.exists(current.resolve("pom.xml"))) {
+                return current
+            }
+            current = current.getParent()
+        }
+        return null
+    }
+
+    private static Path findAppRoot(final Path start) {
+        Path current = start
+        while (current != null) {
+            if (Files.exists(current.resolve("resources")) ||
+                Files.exists(current.resolve("plugins"))
+            ) {
+                return current
+            }
+            current = current.getParent()
+        }
+        return null
+    }
+
+    static Path getPluginsDirPath() throws URISyntaxException {
+        URL url = MauroPluginUtil.getProtectionDomain().getCodeSource().getLocation()
+        Path baseDirPath = Paths.get(url.toURI())
+
+        final Path pluginsDirPath
+
+        if (Files.isDirectory(baseDirPath)) {
+            // Application is in an IDE
+            pluginsDirPath = findProjectRoot(baseDirPath)?.resolve("plugins")
+            log.debug("Application IDE Plugin base directory ${baseDirPath}")
+        } else {
+            // Application is in a packaged jar
+            pluginsDirPath = findAppRoot(baseDirPath.getParent())?.resolve("plugins")
+            log.debug("Application Plugin base directory ${baseDirPath}")
+        }
+
+        return pluginsDirPath
+    }
+}

--- a/mauro-domain/src/main/groovy/org/maurodata/plugin/MauroPluginUtil.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/plugin/MauroPluginUtil.groovy
@@ -11,7 +11,7 @@ import java.nio.file.Paths
 @Slf4j
 class MauroPluginUtil {
 
-    private static Path findProjectRoot(final Path start) {
+    static Path findProjectRoot(final Path start) {
         Path current = start
         while (current != null) {
             if (Files.exists(current.resolve("build.gradle")) ||
@@ -23,7 +23,7 @@ class MauroPluginUtil {
         return null
     }
 
-    private static Path findAppRoot(final Path start) {
+    static Path findAppRoot(final Path start) {
         Path current = start
         while (current != null) {
             if (Files.exists(current.resolve("resources")) ||


### PR DESCRIPTION

Add /api/admin/providers/available to list plugins that are available to download from the repository
Add /api/admin/provider/install/{plugin} to download a plugin from the repository to the plugins directory

Docker docker-environment.sh checks whether /home/app/plugins is mounted on persistent storage and sets a flag
Docker micronaut-startup.sh does not overwrite persisted plugins with those from /opt/init/micronaut and sets -DPLUGINS_IS_MOUNTED 

Move finding the plugins directory from the environment to MauroPluginUtil so that it can be shared

Add PluginRepositoryService that understands the maven repository to list, download, and install plugins

Yet to be connected to the UI, so new AdminController methods returns Map at this point rather than DTOs to allow some wiggle room
