### PR TITLE
Fix for when folder / versioned folder cache is not invalidated

### DIFF
--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/cache/FacetCacheableRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/cache/FacetCacheableRepository.groovy
@@ -52,6 +52,16 @@ abstract class FacetCacheableRepository<F extends Facet> extends ItemCacheableRe
         // invalidate find of the parent item
         invalidateCachedLookupById(FIND_BY_ID, item.multiFacetAwareItemDomainType, item.multiFacetAwareItemId)
 
+        if(item.multiFacetAwareItemDomainType == 'VersionedFolder') {
+            // invalidate find of the parent item for Folder as well
+            invalidateCachedLookupById(FIND_BY_ID, 'Folder', item.multiFacetAwareItemId)
+        }
+
+        if(item.multiFacetAwareItemDomainType == 'Folder') {
+            // invalidate find of the parent item for Folder as well
+            invalidateCachedLookupById(FIND_BY_ID, 'VersionedFolder', item.multiFacetAwareItemId)
+        }
+
         // invalidate findAll of the parent collection
         AdministeredItemCacheableRepository<AdministeredItem> administeredItemAdministeredItemCacheableRepository = getRepository(item.multiFacetAwareItemDomainType)
 


### PR DESCRIPTION
This maybe requires a deeper look at the way domain types are used, or caches are invalidated, or both.