### PR TITLE
Updates to ContextConfigurer for auto-registration of plugins

### DIFF
--- a/mauro-api/src/main/groovy/org/maurodata/controller/MauroApplicationContextConfigurer.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/controller/MauroApplicationContextConfigurer.groovy
@@ -1,5 +1,7 @@
-package org.maurodata.plugin
+package org.maurodata.controller
 
+import io.micronaut.context.annotation.Property
+import org.maurodata.plugin.MauroPlugin
 import org.maurodata.profile.Profile
 
 import groovy.transform.CompileStatic
@@ -33,6 +35,13 @@ import java.util.stream.Stream
 @ContextConfigurer
 class MauroApplicationContextConfigurer implements ApplicationContextConfigurer {
 
+    // Could be enabled in Docker-type deployments;
+    // Should be disabled when running in development mode via gradle, or in live environments where no additional plugins will be required
+    @Property(name = 'mauro.plugins.autoregister', defaultValue = 'true')
+    boolean autoRegisterPlugins
+
+
+
     @Override
     void configure(ApplicationContextBuilder builder) {
         System.out.println("""
@@ -47,29 +56,31 @@ class MauroApplicationContextConfigurer implements ApplicationContextConfigurer 
     @Override
     void configure(ApplicationContext applicationContext) {
 
-        URL url = getClass().getProtectionDomain().getCodeSource().getLocation()
-        Path baseDirPath = Paths.get(url.toURI())
+        if(autoRegisterPlugins) {
 
-        final Path pluginsDirPath
+            URL url = getClass().getProtectionDomain().getCodeSource().getLocation()
+            Path baseDirPath = Paths.get(url.toURI())
 
+            final Path pluginsDirPath
 
-        if (Files.isDirectory(baseDirPath)) {
-            // Application is in an IDE
-            pluginsDirPath = findProjectRoot(baseDirPath)?.resolve("plugins")
-            log.debug("Application IDE Plugin base directory ${baseDirPath}")
-        } else {
-            // Application is in a packaged jar
-            pluginsDirPath = findAppRoot(baseDirPath.getParent())?.resolve("plugins")
-            log.debug("Application Plugin base directory ${baseDirPath}")
-        }
+            if (Files.isDirectory(baseDirPath)) {
+                // Application is in an IDE
+                pluginsDirPath = findProjectRoot(baseDirPath)?.resolve("plugins")
+                log.debug("Application IDE Plugin base directory ${baseDirPath}")
+            } else {
+                // Application is in a packaged jar
+                pluginsDirPath = findAppRoot(baseDirPath.getParent())?.resolve("plugins")
+                log.debug("Application Plugin base directory ${baseDirPath}")
+            }
 
-        if (pluginsDirPath == null) {
-            log.warn("Failed to locate plugins directory")
-            return
-        }
+            if (pluginsDirPath == null) {
+                log.warn("Failed to locate plugins directory")
+                return
+            }
 
-        if (Files.exists(pluginsDirPath)) {
-            loadPlugins(pluginsDirPath, applicationContext)
+            if (Files.exists(pluginsDirPath)) {
+                loadPlugins(pluginsDirPath, applicationContext)
+            }
         }
     }
 

--- a/mauro-api/src/main/resources/application.yml
+++ b/mauro-api/src/main/resources/application.yml
@@ -113,6 +113,8 @@ javamail:
         host: $$host$$ # Replace me!
 
 mauro:
+  plugins:
+    autoregister: false
   federation:
     subscribed-catalogues.max: 50
   audit:

--- a/ready-configuration/quick-start/init/micronaut/application-mauro.yml
+++ b/ready-configuration/quick-start/init/micronaut/application-mauro.yml
@@ -1,15 +1,17 @@
 mauro:
-  users:
+    plugins:
+        autoregister: true
+    users:
     -   email: admin@maurodatamapper.com
         first-name: admin
         last-name: admin
         temp-password: password
-  groups:
+    groups:
     -   name: Administrators
         isAdmin: true
         members:
           - admin@maurodatamapper.com
-  api-keys:
+    api-keys:
     -   name: My first API Key
         email: admin@maurodatamapper.com
         refreshable: true


### PR DESCRIPTION
Move ContextConfigurer into API so that it isn't included when the domain is used in a different app.

Add configuration to allow disabling auto-registration of plugins for gradle builds.  Set defaults for quickstart docker environment as well as application.yml