### PR TITLE
Fix for DataModel-based profiles

### DIFF
--- a/mauro-domain/src/main/groovy/org/maurodata/profile/DataModelBasedProfile.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/profile/DataModelBasedProfile.groovy
@@ -43,7 +43,7 @@ class DataModelBasedProfile implements Profile {
 
     @Override
     List<String> getProfileApplicableForDomains() {
-        (metadataMap["profileApplicableForDomains"]?:"").split(";").collect {it.trim()}
+        (metadataMap["domainsApplicable"]?:"").split(";").collect {it.trim()}
     }
 
     DataModelBasedProfile(DataModel dataModel) {

--- a/mauro-domain/src/main/groovy/org/maurodata/profile/test/DataModelBasedProfileTest.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/profile/test/DataModelBasedProfileTest.groovy
@@ -16,7 +16,7 @@ class DataModelBasedProfileTest {
         finalised true
         metadata(ProfileSpecificationProfile.NAMESPACE,
                  ["metadataNamespace"          : testProfileModelNamespace,
-                  "profileApplicableForDomains": "DataModel; Terminology"])
+                  "domainsApplicable": "DataModel; Terminology"])
         primitiveType {
             label "Decimal"
         }

--- a/mauro-persistence/src/test/groovy/org/maurodata/persistence/profile/DynamicProfileServiceSpec.groovy
+++ b/mauro-persistence/src/test/groovy/org/maurodata/persistence/profile/DynamicProfileServiceSpec.groovy
@@ -84,7 +84,7 @@ class DynamicProfileServiceSpec extends Specification {
 
 
         metadataRepository.getNamespaceKeys() == [
-                "org.maurodata.profile": ["metadataNamespace","profileApplicableForDomains"] as Set,
+                "org.maurodata.profile": ["metadataNamespace","domainsApplicable"] as Set,
                 "org.maurodata.profile.dataelement":["metadataPropertyName", "regularExpression"] as Set
         ]
 


### PR DESCRIPTION
Change the DataModelBasedProfile metadata property for 'domains applicable' as it was inconsitently set / read.