### PR TITLE
Various fixes for viewing merge diffs, and applying a merge, across a Versioned Folder

### DIFF
--- a/mauro-api/src/main/groovy/org/maurodata/controller/datamodel/DataClassController.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/controller/datamodel/DataClassController.groovy
@@ -116,6 +116,7 @@ class DataClassController extends AdministeredItemController<DataClass, DataMode
     HttpResponse delete(UUID dataModelId, UUID id, @Body @Nullable DataClass dataClass) {
         DataClass dataClassToDelete = dataClassRepository.loadWithContent(id)
         ErrorHandler.handleErrorOnNullObject(HttpStatus.NOT_FOUND, dataClassToDelete, "DataClass $id not found")
+        pathRepository.readParentItems(dataClassToDelete)
         deleteDanglingReferenceTypes(dataClassToDelete.allChildDataClasses(), dataClassToDelete.allChildDataElements())
         HttpResponse deletedResponse = super.delete(id, dataClass)
         deletedResponse

--- a/mauro-api/src/main/groovy/org/maurodata/controller/model/AdministeredItemController.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/controller/model/AdministeredItemController.groovy
@@ -143,8 +143,8 @@ abstract class AdministeredItemController<I extends AdministeredItem, P extends 
         if (itemToDelete == null) {
             throw new HttpStatusException(HttpStatus.NOT_FOUND, "Object not found for deletion")
         }
-
-        accessControlService.checkRole(Role.EDITOR, item)
+        pathRepository.readParentItems(itemToDelete)
+        accessControlService.checkRole(Role.EDITOR, itemToDelete)
 
         if (item?.version) itemToDelete.version = item.version
 

--- a/mauro-api/src/main/groovy/org/maurodata/controller/model/ModelController.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/controller/model/ModelController.groovy
@@ -44,6 +44,7 @@ import org.maurodata.domain.facet.ReferenceFile
 import org.maurodata.domain.facet.VersionLink
 import org.maurodata.domain.folder.Folder
 import org.maurodata.domain.model.AdministeredItem
+import org.maurodata.domain.model.Breadcrumb
 import org.maurodata.domain.model.Item
 import org.maurodata.domain.model.ItemReference
 import org.maurodata.domain.model.ItemReferencer
@@ -56,6 +57,8 @@ import org.maurodata.domain.model.version.ModelVersion
 import org.maurodata.domain.security.CatalogueUser
 import org.maurodata.domain.security.Role
 import org.maurodata.domain.security.UserGroup
+import org.maurodata.domain.terminology.CodeSet
+import org.maurodata.domain.terminology.Term
 import org.maurodata.persistence.ContentsService
 import org.maurodata.persistence.cache.AdministeredItemCacheableRepository
 import org.maurodata.persistence.cache.FacetCacheableRepository
@@ -1067,7 +1070,7 @@ abstract class ModelController<M extends Model> extends AdministeredItemControll
                     ancestorBasedPath = new Path(ancestorBasedPath.nodes)
 
                     final MergeFieldDiffDTO mergeFieldDiffDTO = new MergeFieldDiffDTO(fieldName: fieldName, sourceValue: null, targetValue: null,
-                                                                                      commonAncestorValue: null, isMergeConflict: true, _type: "deletion",
+                                                                                      commonAncestorValue: null, isMergeConflict: false, _type: "deletion",
                                                                                       path: ancestorBasedPath)
                     diffs.add(mergeFieldDiffDTO)
                 }
@@ -1108,7 +1111,7 @@ abstract class ModelController<M extends Model> extends AdministeredItemControll
                             ancestorBasedPath = new Path(ancestorBasedPath.nodes)
 
                             final MergeFieldDiffDTO mergeFieldDiffDTO = new MergeFieldDiffDTO(fieldName: fieldName, sourceValue: null, targetValue: null,
-                                                                                              commonAncestorValue: null, isMergeConflict: true, _type: "deletion",
+                                                                                              commonAncestorValue: null, isMergeConflict: false, _type: "deletion",
                                                                                               path: ancestorBasedPath)
                             diffs.add(mergeFieldDiffDTO)
                         }
@@ -1149,7 +1152,7 @@ abstract class ModelController<M extends Model> extends AdministeredItemControll
                             ancestorBasedPath = new Path(ancestorBasedPath.nodes)
 
                             final MergeFieldDiffDTO mergeFieldDiffDTO = new MergeFieldDiffDTO(fieldName: fieldName, sourceValue: null, targetValue: null,
-                                                                                              commonAncestorValue: null, isMergeConflict: true, _type: "deletion",
+                                                                                              commonAncestorValue: null, isMergeConflict: false, _type: "deletion",
                                                                                               path: ancestorBasedPath)
                             diffs.add(mergeFieldDiffDTO)
                         }
@@ -1190,7 +1193,7 @@ abstract class ModelController<M extends Model> extends AdministeredItemControll
                             ancestorBasedPath = new Path(ancestorBasedPath.nodes)
 
                             final MergeFieldDiffDTO mergeFieldDiffDTO = new MergeFieldDiffDTO(fieldName: fieldName, sourceValue: null, targetValue: null,
-                                                                                              commonAncestorValue: null, isMergeConflict: true, _type: "deletion",
+                                                                                              commonAncestorValue: null, isMergeConflict: false, _type: "deletion",
                                                                                               path: ancestorBasedPath)
                             diffs.add(mergeFieldDiffDTO)
                         }
@@ -1384,9 +1387,14 @@ abstract class ModelController<M extends Model> extends AdministeredItemControll
             // delete the model
         }
 
-        administeredItemRepository.update(targetModel)
+        M alreadySavedTargetModel = administeredItemRepository.readById(targetModel.id)
+        if(alreadySavedTargetModel.version <= targetModel.version) { // If saving the parent above didn't already save this one.
+            administeredItemRepository.update(targetModel)
+        }
 
-        targetModel
+        // return a smaller subset of the target model
+        return administeredItemRepository.readById(targetModel.id)
+
     }
 
     List<FieldPatchDataDTO> getSortedFieldPatchDataForMerging(ObjectPatchDataDTO objectPatchData) {
@@ -1456,7 +1464,15 @@ abstract class ModelController<M extends Model> extends AdministeredItemControll
         }
 
         // Make a copy of the AdministeredItem from the source, then attach the copy to the target parent
-        final AdministeredItem clonedAdministeredItem = administeredItemSource.clone()
+
+        IdentityHashMap<Item, Item> replacements = new IdentityHashMap<>(4096)
+
+        // If there is a parent, don't clone it, reference it
+        if (administeredItemSource.parent != null) {
+            replacements.put(administeredItemSource.parent, administeredItemTargetParent)
+        }
+
+        final AdministeredItem clonedAdministeredItem = administeredItemSource.deepClone(replacements) as AdministeredItem
 
         // reset any properties to do with versioning or branches etc and, of course, the Id as it will
         // need a new one
@@ -1482,7 +1498,17 @@ abstract class ModelController<M extends Model> extends AdministeredItemControll
         clonedAdministeredItem.updatePath()
         clonedAdministeredItem.updateBreadcrumbs()
         AdministeredItemRepository simpleRepositoryToUse = pathRepository.getRepository(clonedAdministeredItem)
-        final AdministeredItem savedClonedAdministeredItem = (AdministeredItem) simpleRepositoryToUse.save(clonedAdministeredItem)
+
+        final AdministeredItem savedClonedAdministeredItem
+        if(clonedAdministeredItem instanceof CodeSet) {
+            Set<Term> oldTerms = [] as Set
+            oldTerms.addAll(clonedAdministeredItem.terms)
+            clonedAdministeredItem.terms = [] as Set
+            savedClonedAdministeredItem = simpleRepositoryToUse.save(clonedAdministeredItem) as CodeSet
+            clonedAdministeredItem.terms.addAll(oldTerms)
+        } else {
+            savedClonedAdministeredItem = (AdministeredItem) simpleRepositoryToUse.save(clonedAdministeredItem)
+        }
 
         /*
          Is this clonedAdministeredItem referencing something within the scope of its own 'versionable' (Versioned folder, Data model)?
@@ -1510,12 +1536,12 @@ abstract class ModelController<M extends Model> extends AdministeredItemControll
             List<ItemReference> referencedItems = itemReferencer.retrieveItemReferences()
 
             // Resolve these to a list of paths
-            List<Path> pathsToReferencedItems = pathRepository.resolveItemReferences(referencedItems)
+            Map<Path, ItemReference> pathsToReferencedItems = pathRepository.resolveItemReferences(referencedItems)
 
             // Are any of these paths inside the source model?
             final IdentityHashMap<Item, Item> toReplace = new IdentityHashMap<>(pathsToReferencedItems.size())
-            for (int p = 0; p < pathsToReferencedItems.size(); p++) {
-                Path pathToReferencedItem = pathsToReferencedItems.get(p)
+            final HashMap<UUID, Item> toReplaceById = new HashMap<>(pathsToReferencedItems.size())
+            pathsToReferencedItems.each {pathToReferencedItem, itemReference ->
 
                 Path pathToReferencedItemFromSource = pathToReferencedItem.trimUntil(sourceModel.pathNodeString)
 
@@ -1568,23 +1594,35 @@ abstract class ModelController<M extends Model> extends AdministeredItemControll
                     }
 
                     // Record a map of the ItemReferences the ItemReferencer will need to update to use the new reference
-                    toReplace.put(sourceOfReferencedItem, targetToReferencedItem)
+                    if(itemReference.theItem) {
+                        toReplace.put(itemReference.theItem, targetToReferencedItem)
+                    } else {
+                        toReplace.put(targetToReferencedItem, targetToReferencedItem)
+                    }
+                    toReplaceById.put(itemReference.itemId, targetToReferencedItem)
                 }
             }
 
             // Ask the ItemReferencer to update to use the cloned items
-            Map<UUID, Item> toReplaceById = toReplace.values().collectEntries { value -> [value.id, value]}
+            // Map<UUID, Item> toReplaceById =
+            //    toReplace.collectEntries {source, target ->
+            //        [source.id, target]
+            //    }
+                //toReplace.values().collectEntries { value -> [value.id, value]}
             itemReferencer.replaceItemReferencesByIdentity(toReplace, toReplaceById)
-
             // Then for each item, call update
 
             toReplace.values().forEach {Item replacedItem ->
 
                 if (replacedItem instanceof AdministeredItem) {
                     AdministeredItem replacedItemAdministeredItem = (AdministeredItem) replacedItem
-                    getAdministeredItemRepository(replacedItem.domainType).update(replacedItemAdministeredItem)
+                    AdministeredItem alreadySavedAdministeredItem = getAdministeredItemRepository(replacedItem.domainType).repository.readById(replacedItemAdministeredItem.id) as AdministeredItem
+                    if(alreadySavedAdministeredItem.version <= replacedItemAdministeredItem.version) { // If saving the parent above didn't already save this one.
+                        getAdministeredItemRepository(replacedItem.domainType).update(replacedItemAdministeredItem)
+                    }
                 }
             }
+            getAdministeredItemRepository(savedClonedAdministeredItem.domainType).update(savedClonedAdministeredItem)
         }
 
         // Record edits

--- a/mauro-api/src/test/groovy/org/maurodata/datamodel/diff/DataModelSchemaMergeDiffsIntegrationSpec.groovy
+++ b/mauro-api/src/test/groovy/org/maurodata/datamodel/diff/DataModelSchemaMergeDiffsIntegrationSpec.groovy
@@ -242,7 +242,7 @@ class DataModelSchemaMergeDiffsIntegrationSpec extends CommonDataSpec {
 
         then:
         mergeDiff.diffs.every {
-            it.fieldName == 'dataClasses' && it.isMergeConflict && it._type == 'deletion'
+            it.fieldName == 'dataClasses' && !it.isMergeConflict && it._type == 'deletion'
         }
     }
 
@@ -282,10 +282,10 @@ class DataModelSchemaMergeDiffsIntegrationSpec extends CommonDataSpec {
 
         then:
         mergeDiff.diffs.any {
-            it.fieldName == 'dataClasses' && it.isMergeConflict && it._type == 'deletion' && it.path=='dm:test label $main|dc:A data class'
+            it.fieldName == 'dataClasses' && !it.isMergeConflict && it._type == 'deletion' && it.path=='dm:test label $main|dc:A data class'
         }
         mergeDiff.diffs.any {
-            it.fieldName == 'dataClasses' && it.isMergeConflict && it._type == 'deletion' && it.path=='dm:test label $main|dc:A data class|dc:Test child'
+            it.fieldName == 'dataClasses' && !it.isMergeConflict && it._type == 'deletion' && it.path=='dm:test label $main|dc:A data class|dc:Test child'
         }
     }
 

--- a/mauro-api/src/test/groovy/org/maurodata/folder/VersionedFolderMergeIntegrationSpec.groovy
+++ b/mauro-api/src/test/groovy/org/maurodata/folder/VersionedFolderMergeIntegrationSpec.groovy
@@ -1,0 +1,114 @@
+package org.maurodata.folder
+
+import jakarta.inject.Singleton
+import org.maurodata.api.model.MergeDiffDTO
+import org.maurodata.api.model.MergeIntoDTO
+import org.maurodata.domain.datamodel.DataClass
+import org.maurodata.domain.datamodel.DataModel
+import org.maurodata.domain.folder.Folder
+import org.maurodata.domain.model.version.CreateNewVersionData
+import org.maurodata.domain.terminology.Term
+import org.maurodata.domain.terminology.Terminology
+import org.maurodata.persistence.ContainerizedTest
+import org.maurodata.testing.CommonDataSpec
+import org.maurodata.web.ListResponse
+import spock.lang.Shared
+
+@ContainerizedTest
+@Singleton
+class VersionedFolderMergeIntegrationSpec extends CommonDataSpec {
+
+    @Shared
+    UUID storedBaseFolderId
+
+    @Shared
+    UUID storedBranch1FolderId
+
+    @Shared
+    UUID storedBranch2FolderId
+
+    @Shared
+    Folder baseFolder = Folder.build {
+        finalised true
+        modelVersion '1.0.0'
+        modelVersionTag 'BaseVersion'
+        label 'Test Merge Folder'
+        dataModel {
+            label 'My first dataModel'
+            dataClass {
+                label 'My first dataClass'
+            }
+        }
+        terminology {
+            label 'My first Terminology'
+            term {
+                code 'Y'
+                definition 'Yes!'
+            }
+            term {
+                code 'N'
+                definition 'Definitely not!'
+            }
+        }
+    }
+
+    void setupSpec() {
+        Folder folder = folderApi.create(new Folder(label: 'Test'))
+        //        folderApi.delete(folder.id, new Folder(id: folder.id), true)
+        //        folder = findOrCreateFolderByLabel('Test')
+        storedBaseFolderId = importFolder(baseFolder, folder)
+        Folder mainFolder = versionedFolderApi.createNewBranchModelVersion(storedBaseFolderId, new CreateNewVersionData())
+        storedBranch1FolderId = mainFolder.id
+        Folder branchFolder = versionedFolderApi.
+            createNewBranchModelVersion(storedBaseFolderId, new CreateNewVersionData(branchName: 'My New Branch'))
+
+        storedBranch2FolderId = branchFolder.id
+        ListResponse<DataModel> branchDataModels = dataModelApi.list(storedBranch2FolderId)
+        ListResponse<Terminology> branchTerminologies = terminologyApi.list(storedBranch2FolderId)
+        ListResponse<Terminology> mainTerminologies = terminologyApi.list(storedBranch2FolderId)
+
+        // delete something in the branch
+        ListResponse<DataClass> branchDataClasses = dataClassApi.list(branchDataModels.items.first().id)
+        dataClassApi.delete(branchDataModels.items.first().id, branchDataClasses.items.first().id, new DataClass())
+
+        // add something in the branch
+        dataModelApi.create(storedBranch2FolderId, new DataModel(
+            label: 'My second DataModel'
+        ))
+
+        // modify something in one branch
+        ListResponse<Term> branchTerms = termApi.list(branchTerminologies.items.first().id)
+        Term branchYTerm = branchTerms.items.find {it.code == 'Y'}
+        termApi.update(branchTerminologies.items.first().id, branchYTerm.id, new Term(code: 'Y', definition: 'Maybe!'))
+
+        // modify something in both branches
+        Term branchNTerm = branchTerms.items.find {it.code == 'N'}
+        termApi.update(branchTerminologies.items.first().id, branchNTerm.id, new Term(code: 'N', definition: 'Definitely Yes!'))
+
+        ListResponse<Term> mainTerms = termApi.list(mainTerminologies.items.first().id)
+        Term mainNTerm = mainTerms.items.find {it.code == 'N'}
+        termApi.update(mainTerminologies.items.first().id, mainNTerm.id, new Term(code: 'N', definition: 'Definitely No!'))
+
+    }
+
+
+    void "Test merge on folders"() {
+
+        when:
+        MergeDiffDTO mergeDiffDTO = versionedFolderApi.mergeDiff(storedBranch2FolderId, storedBranch1FolderId)
+        then:
+
+        mergeDiffDTO.sourceId == storedBranch2FolderId
+        mergeDiffDTO.targetId == storedBranch1FolderId
+
+        mergeDiffDTO.diffs.size() == 4
+
+        // MergeIntoDTO mergeIntoDTO = new
+
+
+        // versionedFolderApi.mergeInto(storedBranch2FolderId, storedBranch1FolderId, )
+
+    }
+
+
+}

--- a/mauro-api/src/test/groovy/org/maurodata/testing/CommonDataSpec.groovy
+++ b/mauro-api/src/test/groovy/org/maurodata/testing/CommonDataSpec.groovy
@@ -78,6 +78,7 @@ import org.maurodata.domain.terminology.Terminology
 import org.maurodata.export.ExportModel
 import org.maurodata.importdata.ImportMetadata
 import org.maurodata.plugin.importer.json.JsonDataModelImporterPlugin
+import org.maurodata.plugin.importer.json.JsonFolderImporterPlugin
 import org.maurodata.plugin.importer.json.JsonTerminologyImporterPlugin
 import org.maurodata.web.ListResponse
 
@@ -109,6 +110,8 @@ class CommonDataSpec extends Specification {
 
     @Inject
     JsonTerminologyImporterPlugin jsonTerminologyImporterPlugin
+    @Inject
+    JsonFolderImporterPlugin jsonFolderImporterPlugin
 
     @Inject
     ObjectMapper objectMapper
@@ -380,6 +383,22 @@ class CommonDataSpec extends Specification {
         String version = jsonTerminologyImporterPlugin.version
 
         ListResponse<Terminology> response = terminologyApi.importModel(importRequest, namespace, name, version)
+        response.items.first().id
+    }
+
+    UUID importFolder(Folder folderToImport, Folder parentFolder) {
+        ExportModel exportModel = ExportModel.build {
+            folder folderToImport
+        }
+        MultipartBody importRequest = MultipartBody.builder()
+            .addPart('folderId', parentFolder.id.toString())
+            .addPart('importFile', 'file.json', MediaType.APPLICATION_JSON_TYPE, objectMapper.writeValueAsBytes(exportModel))
+            .build()
+        String namespace = jsonFolderImporterPlugin.namespace
+        String name = jsonFolderImporterPlugin.name
+        String version = jsonFolderImporterPlugin.version
+
+        ListResponse<Folder> response = folderApi.importModel(importRequest, namespace, name, version)
         response.items.first().id
     }
 

--- a/mauro-client/src/main/groovy/org/maurodata/ApiClient.groovy
+++ b/mauro-client/src/main/groovy/org/maurodata/ApiClient.groovy
@@ -22,6 +22,7 @@ import org.maurodata.api.facet.ReferenceFileApi
 import org.maurodata.api.facet.SummaryMetadataApi
 import org.maurodata.api.facet.SummaryMetadataReportApi
 import org.maurodata.api.folder.FolderApi
+import org.maurodata.api.folder.VersionedFolderApi
 import org.maurodata.api.importer.ImporterApi
 import org.maurodata.api.profile.ProfileApi
 import org.maurodata.api.search.SearchApi
@@ -89,6 +90,7 @@ abstract class ApiClient {
     @Inject SummaryMetadataApi summaryMetadataApi
     @Inject SummaryMetadataReportApi summaryMetadataReportApi
     @Inject FolderApi folderApi
+    @Inject VersionedFolderApi versionedFolderApi
     @Inject ImporterApi importerApi
     @Inject ProfileApi profileApi
     @Inject SearchApi searchApi

--- a/mauro-client/src/main/groovy/org/maurodata/api/model/MergeFieldDiffDTO.groovy
+++ b/mauro-client/src/main/groovy/org/maurodata/api/model/MergeFieldDiffDTO.groovy
@@ -1,11 +1,13 @@
 package org.maurodata.api.model
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import org.maurodata.domain.model.Breadcrumb
 
 class MergeFieldDiffDTO {
 
     String fieldName
     String path
+    List<Breadcrumb> breadcrumbs
     Object sourceValue
     Object targetValue
     Object commonAncestorValue

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/classifier/ClassificationScheme.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/classifier/ClassificationScheme.groovy
@@ -1,6 +1,12 @@
 package org.maurodata.domain.classifier
 
 import jakarta.persistence.PrePersist
+import jakarta.persistence.PreUpdate
+import org.maurodata.domain.diff.BaseCollectionDiff
+import org.maurodata.domain.diff.CollectionDiff
+import org.maurodata.domain.diff.DiffBuilder
+import org.maurodata.domain.diff.DiffableItem
+import org.maurodata.domain.diff.ObjectDiff
 import org.maurodata.domain.model.Item
 import org.maurodata.domain.model.ItemReference
 import org.maurodata.domain.model.ItemReferencer
@@ -27,7 +33,7 @@ import org.maurodata.domain.model.ModelItem
 @Introspected
 @MappedEntity(schema = 'core')
 @MapConstructor(includeSuperFields = true, includeSuperProperties = true, noArg = true)
-class ClassificationScheme extends Model implements ItemReferencer {
+class ClassificationScheme extends Model implements ItemReferencer, DiffableItem<ClassificationScheme> {
 
     @Relation(value = Relation.Kind.ONE_TO_MANY, mappedBy = 'classificationScheme')
     @JsonAlias("classifiers") // for importing models exported from the Grails implementation
@@ -139,11 +145,29 @@ class ClassificationScheme extends Model implements ItemReferencer {
     }
 
     @PrePersist
+    @PreUpdate
     void prePersist() {
         super.prePersist()
         if (!getModelWithVersion()) {
             branchName = 'main'
         }
+    }
+
+    @Override
+    @JsonIgnore
+    @Transient
+    ObjectDiff<ClassificationScheme> diff(ClassificationScheme other, String lhsPathRoot, String rhsPathRoot) {
+        ObjectDiff<ClassificationScheme> base = DiffBuilder.objectDiff(ClassificationScheme)
+            .leftHandSide(id?.toString(), this)
+            .rightHandSide(other.id?.toString(), other)
+        base.label = this.label
+        base.appendString(DiffBuilder.DESCRIPTION, this.description, other.description, this, other)
+        base.appendString(DiffBuilder.ALIASES_STRING, this.aliasesString, other.aliasesString, this, other)
+        if (!DiffBuilder.isNullOrEmpty(this.classifiers as Collection<Object>) || !DiffBuilder.isNullOrEmpty(other.classifiers as Collection<Object>)) {
+            base.appendCollection(DiffBuilder.CLASSIFIERS, this.classifiers as Collection<DiffableItem>, other.classifiers as Collection<DiffableItem>, lhsPathRoot,
+                                  rhsPathRoot)
+        }
+        base
     }
 
 

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/classifier/Classifier.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/classifier/Classifier.groovy
@@ -86,13 +86,6 @@ class Classifier extends ModelItem<ClassificationScheme> implements DiffableItem
     @Override
     @JsonIgnore
     @Transient
-    CollectionDiff fromItem() {
-        new BaseCollectionDiff(id, getDiffIdentifier(), label)
-    }
-
-    @Override
-    @JsonIgnore
-    @Transient
     String getDiffIdentifier() {
         if (parentClassifier != null) {return "${parentClassifier.getDiffIdentifier()}|${getPathNodeString()}"}
         if (classificationScheme != null) {return "${classificationScheme.getDiffIdentifier()}|${getPathNodeString()}"}

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/dataflow/DataClassComponent.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/dataflow/DataClassComponent.groovy
@@ -1,5 +1,7 @@
 package org.maurodata.domain.dataflow
 
+import org.maurodata.domain.diff.DiffableItem
+import org.maurodata.domain.diff.ObjectDiff
 import org.maurodata.domain.model.Item
 import org.maurodata.domain.model.ItemUtils
 
@@ -101,5 +103,11 @@ class DataClassComponent extends ModelItem<DataFlow> {
         DataClassComponent dataClassComponentShallowCopy = new DataClassComponent()
         this.copyInto(dataClassComponentShallowCopy)
         return dataClassComponentShallowCopy
+    }
+
+    //TODO : Implement this
+    @Override
+    ObjectDiff diff(DiffableItem other, String lhsPathRoot, String rhsPathRoot) {
+        return null
     }
 }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/dataflow/DataElementComponent.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/dataflow/DataElementComponent.groovy
@@ -1,5 +1,7 @@
 package org.maurodata.domain.dataflow
 
+import org.maurodata.domain.diff.DiffableItem
+import org.maurodata.domain.diff.ObjectDiff
 import org.maurodata.domain.model.Item
 import org.maurodata.domain.model.ItemUtils
 
@@ -95,5 +97,11 @@ class DataElementComponent extends ModelItem<DataClassComponent> {
         DataElementComponent dataElementComponentShallowCopy = new DataElementComponent()
         this.copyInto(dataElementComponentShallowCopy)
         return dataElementComponentShallowCopy
+    }
+
+    //TODO : Implement this
+    @Override
+    ObjectDiff diff(DiffableItem other, String lhsPathRoot, String rhsPathRoot) {
+        return null
     }
 }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/dataflow/DataFlow.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/dataflow/DataFlow.groovy
@@ -1,5 +1,7 @@
 package org.maurodata.domain.dataflow
 
+import org.maurodata.domain.diff.DiffableItem
+import org.maurodata.domain.diff.ObjectDiff
 import org.maurodata.domain.model.Item
 import org.maurodata.domain.model.ItemUtils
 
@@ -133,5 +135,11 @@ class DataFlow extends ModelItem<DataModel> {
     static DataFlow build(
         @DelegatesTo(value = DataFlow, strategy = Closure.DELEGATE_FIRST) Closure closure = {}) {
         build [:], closure
+    }
+
+    //TODO : Implement this
+    @Override
+    ObjectDiff diff(DiffableItem other, String lhsPathRoot, String rhsPathRoot) {
+        return null
     }
 }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/DataClass.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/DataClass.groovy
@@ -143,14 +143,6 @@ class DataClass extends ModelItem<DataModel> implements DiffableItem<DataClass>,
     @Override
     @JsonIgnore
     @Transient
-    CollectionDiff fromItem() {
-        new BaseCollectionDiff(id, getDiffIdentifier(), label)
-    }
-
-
-    @Override
-    @JsonIgnore
-    @Transient
     String getDiffIdentifier() {
         if (parentDataClass != null) {
             return "${parentDataClass.diffIdentifier}|${getPathNodeString()}"

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/DataElement.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/DataElement.groovy
@@ -120,12 +120,6 @@ class DataElement extends ModelItem<DataClass> implements DiffableItem<DataEleme
         'de'
     }
 
-    @Override
-    @Transient
-    @JsonIgnore
-    CollectionDiff fromItem() {
-        new BaseCollectionDiff(id, getDiffIdentifier(), label)
-    }
 
     @Override
     @Transient

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/DataModel.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/DataModel.groovy
@@ -1,6 +1,12 @@
 package org.maurodata.domain.datamodel
 
 import jakarta.persistence.PrePersist
+import jakarta.persistence.PreUpdate
+import org.maurodata.domain.diff.BaseCollectionDiff
+import org.maurodata.domain.diff.CollectionDiff
+import org.maurodata.domain.diff.DiffBuilder
+import org.maurodata.domain.diff.DiffableItem
+import org.maurodata.domain.diff.ObjectDiff
 import org.maurodata.domain.model.Item
 import org.maurodata.domain.model.ItemReference
 import org.maurodata.domain.model.ItemReferencer
@@ -31,7 +37,7 @@ import org.maurodata.domain.model.ModelItem
 @Introspected
 @MappedEntity(schema = 'datamodel')
 @MapConstructor(includeSuperFields = true, includeSuperProperties = true, noArg = true)
-class DataModel extends Model implements ItemReferencer {
+class DataModel extends Model implements ItemReferencer, DiffableItem<DataModel> {
 
     @Relation(value = Relation.Kind.ONE_TO_MANY, mappedBy = 'dataModel')
     List<DataType> dataTypes = []
@@ -72,6 +78,7 @@ class DataModel extends Model implements ItemReferencer {
     }
 
     @PrePersist
+    @PreUpdate
     void prePersist() {
         super.prePersist()
         if (!getModelWithVersion()) {
@@ -170,6 +177,27 @@ class DataModel extends Model implements ItemReferencer {
     String getDiffIdentifier() {
         if (folder != null) {return "${folder.getDiffIdentifier()}|${getPathNodeString()}"}
         return "${getPathNodeString()}"
+    }
+
+    @Override
+    @JsonIgnore
+    @Transient
+    ObjectDiff<DataModel> diff(DataModel other, String lhsPathRoot, String rhsPathRoot) {
+        ObjectDiff<DataModel> base = DiffBuilder.objectDiff(DataModel)
+            .leftHandSide(id?.toString(), this)
+            .rightHandSide(other.id?.toString(), other)
+        base.label = this.label
+        base.appendString(DiffBuilder.DESCRIPTION, this.description, other.description, this, other)
+        base.appendString(DiffBuilder.ALIASES_STRING, this.aliasesString, other.aliasesString, this, other)
+        if (!DiffBuilder.isNullOrEmpty(this.dataClasses as Collection<Object>) || !DiffBuilder.isNullOrEmpty(other.dataClasses as Collection<Object>)) {
+            base.appendCollection(DiffBuilder.DATA_CLASSES, this.dataClasses as Collection<DiffableItem>, other.dataClasses as Collection<DiffableItem>, lhsPathRoot,
+                                  rhsPathRoot)
+        }
+        if (!DiffBuilder.isNullOrEmpty(this.dataTypes as Collection<Object>) || !DiffBuilder.isNullOrEmpty(other.dataTypes as Collection<Object>)) {
+            base.appendCollection(DiffBuilder.DATA_TYPE, this.dataTypes as Collection<DiffableItem>, other.dataTypes as Collection<DiffableItem>, lhsPathRoot,
+                                  rhsPathRoot)
+        }
+        base
     }
 
     @Transient

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/DataType.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/DataType.groovy
@@ -1,6 +1,7 @@
 package org.maurodata.domain.datamodel
 
 import groovy.util.logging.Slf4j
+import jakarta.persistence.PreUpdate
 import org.maurodata.domain.model.Item
 import jakarta.persistence.PrePersist
 import org.maurodata.domain.model.ItemReference
@@ -102,6 +103,7 @@ class DataType extends ModelItem<DataModel> implements DiffableItem<DataType>, I
     @Transient
     Model modelResource
 
+    @PreUpdate
     @PrePersist
     void prePersist() {
         super.prePersist()
@@ -180,12 +182,6 @@ class DataType extends ModelItem<DataModel> implements DiffableItem<DataType>, I
         this.dataTypeKind == DataTypeKind.ENUMERATION_TYPE
     }
 
-    @Override
-    @JsonIgnore
-    @Transient
-    CollectionDiff fromItem() {
-        new BaseCollectionDiff(id, getDiffIdentifier(), label)
-    }
 
     @Override
     @JsonIgnore

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/EnumerationValue.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/EnumerationValue.groovy
@@ -92,12 +92,6 @@ class EnumerationValue extends ModelItem<DataModel> implements DiffableItem<Enum
         key
     }
 
-    @Override
-    @Transient
-    @JsonIgnore
-    CollectionDiff fromItem() {
-        new BaseCollectionDiff(id, getDiffIdentifier(), label)
-    }
 
     @Override
     @Transient

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/ReferenceType.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/datamodel/ReferenceType.groovy
@@ -32,11 +32,6 @@ class ReferenceType extends ModelItem<DataType> implements DiffableItem<Referenc
     }
 
     @Override
-    CollectionDiff fromItem() {
-        new BaseCollectionDiff(id, getDiffIdentifier(), label)
-    }
-
-    @Override
     String getDiffIdentifier() {
         // TODO: Not sure what the path to this is supposed to be
         getPathNodeString()

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/diff/AnnotationDiff.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/diff/AnnotationDiff.groovy
@@ -1,0 +1,22 @@
+package org.maurodata.domain.diff
+
+import groovy.transform.CompileStatic
+import org.maurodata.domain.facet.Annotation
+
+@CompileStatic
+class AnnotationDiff extends CollectionDiff {
+
+    String label
+
+    String description
+
+    Collection<Annotation> childAnnotations
+
+    AnnotationDiff(UUID id, String label, String description, Collection<Annotation> childAnnotations, String diffIdentifier) {
+        super(id,diffIdentifier)
+        this.label = label
+        this.description = description
+        this.childAnnotations = childAnnotations
+    }
+
+}

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/diff/DiffBuilder.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/diff/DiffBuilder.groovy
@@ -24,6 +24,19 @@ class DiffBuilder {
     static final String ANNOTATION = 'annotations'
     static final String DOMAIN_TYPE = 'domainType'
     static final String RULE = 'rules'
+    static final String CHILD_FOLDERS = 'childFolders'
+    static final String DATA_MODELS = 'dataModels'
+    static final String TERMINOLOGIES = 'terminologies'
+    static final String CODE_SETS = 'codeSets'
+    static final String CLASSIFICATION_SCHEMES = 'classificationSchemes'
+    static final String TERMS = 'terms'
+    static final String TERM_RELATIONSHIP_TYPES = 'termRelationshipTypes'
+    static final String TERM_RELATIONSHIPS = 'termRelationships'
+    static final String CODE = 'code'
+    static final String DEFINITION = 'definition'
+    static final String URL = 'url'
+    static final String SOURCE_TERM_RELATIONSHIPS = 'sourceTermRelationships'
+    static final String TARGET_TERM_RELATIONSHIPS = 'targetTermRelationships'
     static final String CHILD_ANNOTATIONS = 'childAnnotations'
     static final String SUMMARY_METADATA = 'summaryMetadata'
     static final String SUMMARY_METADATA_TYPE = 'summaryMetadataType'
@@ -60,7 +73,8 @@ class DiffBuilder {
                                              DIFF_IDENTIFIER, ENUMERATION_VALUES, ALL_DATA_CLASSES, PATH_IDENTIFIER, PATH_PREFIX]
     static final List<String> MODEL_COLLECTION_KEYS = [METADATA, ANNOTATION, RULE, SUMMARY_METADATA, SUMMARY_METADATA_REPORT, REFERENCE_FILES, DATA_CLASSES, DATA_TYPE,
                                                        DATA_ELEMENTS,
-                                                       ENUMERATION_VALUES, REFERENCE_FILES, CLASSIFIERS, REFERENCE_TYPE]
+                                                       ENUMERATION_VALUES, REFERENCE_FILES, CLASSIFIERS, REFERENCE_TYPE,
+                                                       CHILD_FOLDERS, DATA_MODELS, TERMINOLOGIES, CODE_SETS, CLASSIFICATION_SCHEMES]
 
     static ArrayDiff arrayDiff() {
         new ArrayDiff()

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/facet/Annotation.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/facet/Annotation.groovy
@@ -2,6 +2,9 @@ package org.maurodata.domain.facet
 
 import groovy.util.logging.Slf4j
 import jakarta.persistence.PrePersist
+import jakarta.persistence.PreUpdate
+import org.maurodata.domain.diff.AnnotationDiff
+import org.maurodata.domain.diff.RuleDiff
 import org.maurodata.domain.model.Item
 import org.maurodata.domain.model.ItemUtils
 
@@ -48,6 +51,7 @@ class Annotation extends Facet implements DiffableItem<Annotation> {
     List<Annotation> childAnnotations = []
 
     @PrePersist
+    @PreUpdate
     void prePersist() {
         super.prePersist()
         if(parentAnnotation && (!parentAnnotationId || parentAnnotationId != parentAnnotation.id)) {
@@ -79,6 +83,14 @@ class Annotation extends Facet implements DiffableItem<Annotation> {
 
     }
 
+    @Override
+    @JsonIgnore
+    @Transient
+    CollectionDiff fromItem() {
+        new AnnotationDiff(id, label, description, childAnnotations, getDiffIdentifier())
+    }
+
+
     CatalogueUser getCreatedByUser() {
         createdByUser ? createdByUser : catalogueUser
     }
@@ -90,13 +102,6 @@ class Annotation extends Facet implements DiffableItem<Annotation> {
                 childAnnotation.setAssociations()
             }
         }
-    }
-
-    @Override
-    @JsonIgnore
-    @Transient
-    CollectionDiff fromItem() {
-        new BaseCollectionDiff(id, getDiffIdentifier(), label)
     }
 
     @Override

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/facet/Facet.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/facet/Facet.groovy
@@ -4,6 +4,7 @@ import groovy.util.logging.Slf4j
 import io.micronaut.data.annotation.MappedEntity
 import jakarta.persistence.Entity
 import jakarta.persistence.PrePersist
+import jakarta.persistence.PreUpdate
 import org.maurodata.domain.model.ItemReference
 import org.maurodata.domain.model.ItemReferencer
 import org.maurodata.domain.model.ItemReferencerUtils
@@ -40,6 +41,7 @@ abstract class Facet extends Item implements Pathable, ItemReferencer {
     AdministeredItem multiFacetAwareItem
 
     @PrePersist
+    @PreUpdate
     void prePersist() {
         super.prePersist()
         if(!multiFacetAwareItemId) {

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/facet/RuleRepresentation.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/facet/RuleRepresentation.groovy
@@ -1,6 +1,7 @@
 package org.maurodata.domain.facet
 
 import jakarta.persistence.PrePersist
+import jakarta.persistence.PreUpdate
 import org.maurodata.domain.diff.CollectionDiff
 import org.maurodata.domain.diff.DiffBuilder
 import org.maurodata.domain.diff.DiffableItem
@@ -50,6 +51,7 @@ class RuleRepresentation extends Item implements DiffableItem<RuleRepresentation
     }
 
     @PrePersist
+    @PreUpdate
     void prePersist() {
         super.prePersist()
         if(rule) {

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/facet/SemanticLink.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/facet/SemanticLink.groovy
@@ -2,6 +2,7 @@ package org.maurodata.domain.facet
 
 import groovy.util.logging.Slf4j
 import jakarta.persistence.PrePersist
+import jakarta.persistence.PreUpdate
 import org.maurodata.domain.model.AdministeredItem
 import org.maurodata.domain.model.Item
 import org.maurodata.domain.model.ItemReference
@@ -47,6 +48,7 @@ class SemanticLink extends Facet implements ItemReferencer {
     }
 
     @PrePersist
+    @PreUpdate
     void prePersist() {
         super.prePersist()
         if(target) {

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/facet/SummaryMetadataReport.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/facet/SummaryMetadataReport.groovy
@@ -1,6 +1,7 @@
 package org.maurodata.domain.facet
 
 import jakarta.persistence.PrePersist
+import jakarta.persistence.PreUpdate
 import org.maurodata.domain.diff.CollectionDiff
 import org.maurodata.domain.diff.DiffBuilder
 import org.maurodata.domain.diff.DiffableItem
@@ -47,6 +48,7 @@ class SummaryMetadataReport extends Item implements DiffableItem<SummaryMetadata
     Instant reportDate
 
     @PrePersist
+    @PreUpdate
     void prePersist() {
         super.prePersist()
         if(summaryMetadata) {

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/facet/VersionLink.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/facet/VersionLink.groovy
@@ -2,6 +2,7 @@ package org.maurodata.domain.facet
 
 import groovy.util.logging.Slf4j
 import jakarta.persistence.PrePersist
+import jakarta.persistence.PreUpdate
 import org.maurodata.domain.model.Item
 import org.maurodata.domain.model.ItemReference
 import org.maurodata.domain.model.ItemReferencer
@@ -45,6 +46,7 @@ class VersionLink extends Facet implements ItemReferencer {
     String targetModelDomainType
 
     @PrePersist
+    @PreUpdate
     void prePersist() {
         super.prePersist()
         if(target) {

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/folder/Folder.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/folder/Folder.groovy
@@ -1,5 +1,10 @@
 package org.maurodata.domain.folder
 
+import org.maurodata.domain.diff.BaseCollectionDiff
+import org.maurodata.domain.diff.CollectionDiff
+import org.maurodata.domain.diff.DiffBuilder
+import org.maurodata.domain.diff.DiffableItem
+import org.maurodata.domain.diff.ObjectDiff
 import org.maurodata.domain.model.Item
 import org.maurodata.domain.model.ItemReference
 import org.maurodata.domain.model.ItemReferencer
@@ -34,7 +39,7 @@ import org.maurodata.domain.terminology.Terminology
 @MappedEntity(schema = 'core')
 @Indexes([@Index(columns = ['parent_folder_id'])])
 @MapConstructor(includeSuperFields = true, includeSuperProperties = true, noArg = true)
-class Folder extends Model implements ItemReferencer {
+class Folder extends Model implements ItemReferencer, DiffableItem<Folder> {
 
     @JsonIgnore
     @Nullable
@@ -133,6 +138,39 @@ class Folder extends Model implements ItemReferencer {
     String getDiffIdentifier() {
         if (parentFolder != null) {return "${parentFolder.getDiffIdentifier()}|${getPathNodeString()}"}
         return "${getPathNodeString()}"
+    }
+
+    @Override
+    @JsonIgnore
+    @Transient
+    ObjectDiff<Folder> diff(Folder other, String lhsPathRoot, String rhsPathRoot) {
+        ObjectDiff<Folder> base = DiffBuilder.objectDiff(Folder)
+            .leftHandSide(id?.toString(), this)
+            .rightHandSide(other.id?.toString(), other)
+        base.label = this.label
+        base.appendString(DiffBuilder.DESCRIPTION, this.description, other.description, this, other)
+        base.appendString(DiffBuilder.ALIASES_STRING, this.aliasesString, other.aliasesString, this, other)
+        if (!DiffBuilder.isNullOrEmpty(this.childFolders as Collection<Object>) || !DiffBuilder.isNullOrEmpty(other.childFolders as Collection<Object>)) {
+            base.appendCollection(DiffBuilder.CHILD_FOLDERS, this.childFolders as Collection<DiffableItem>, other.childFolders as Collection<DiffableItem>, lhsPathRoot,
+                                  rhsPathRoot)
+        }
+        if (!DiffBuilder.isNullOrEmpty(this.dataModels as Collection<Object>) || !DiffBuilder.isNullOrEmpty(other.dataModels as Collection<Object>)) {
+            base.appendCollection(DiffBuilder.DATA_MODELS, this.dataModels as Collection<DiffableItem>, other.dataModels as Collection<DiffableItem>, lhsPathRoot,
+                                  rhsPathRoot)
+        }
+        if (!DiffBuilder.isNullOrEmpty(this.terminologies as Collection<Object>) || !DiffBuilder.isNullOrEmpty(other.terminologies as Collection<Object>)) {
+            base.appendCollection(DiffBuilder.TERMINOLOGIES, this.terminologies as Collection<DiffableItem>, other.terminologies as Collection<DiffableItem>, lhsPathRoot,
+                                  rhsPathRoot)
+        }
+        if (!DiffBuilder.isNullOrEmpty(this.codeSets as Collection<Object>) || !DiffBuilder.isNullOrEmpty(other.codeSets as Collection<Object>)) {
+            base.appendCollection(DiffBuilder.CODE_SETS, this.codeSets as Collection<DiffableItem>, other.codeSets as Collection<DiffableItem>, lhsPathRoot,
+                                  rhsPathRoot)
+        }
+        if (!DiffBuilder.isNullOrEmpty(this.classificationSchemes as Collection<Object>) || !DiffBuilder.isNullOrEmpty(other.classificationSchemes as Collection<Object>)) {
+            base.appendCollection(DiffBuilder.CLASSIFICATION_SCHEMES, this.classificationSchemes as Collection<DiffableItem>, other.classificationSchemes as Collection<DiffableItem>, lhsPathRoot,
+                                  rhsPathRoot)
+        }
+        base
     }
 
     @Override

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/model/AdministeredItem.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/model/AdministeredItem.groovy
@@ -2,6 +2,9 @@ package org.maurodata.domain.model
 
 import groovy.util.logging.Slf4j
 import org.maurodata.domain.classifier.Classifier
+import org.maurodata.domain.diff.BaseCollectionDiff
+import org.maurodata.domain.diff.CollectionDiff
+import org.maurodata.domain.diff.DiffableItem
 import org.maurodata.domain.facet.Annotation
 import org.maurodata.domain.facet.Edit
 import org.maurodata.domain.facet.Facet
@@ -38,7 +41,7 @@ import java.time.Instant
 @CompileStatic
 @AutoClone
 @Slf4j
-abstract class AdministeredItem extends Item implements Pathable {
+abstract class AdministeredItem extends Item implements Pathable, DiffableItem {
 
     /**
      * The label of an object.  Labels are used as identifiers within a context and so need to be unique within
@@ -70,7 +73,7 @@ abstract class AdministeredItem extends Item implements Pathable {
         aliasesString?.split(";") as List
     }
 
-    @Transient
+    //@Transient
     @Relation(Relation.Kind.ONE_TO_MANY)
     List<Classifier> classifiers = []
 
@@ -272,12 +275,23 @@ abstract class AdministeredItem extends Item implements Pathable {
         (new Path.PathNode(prefix: this.pathPrefix, identifier: this.pathIdentifier, modelIdentifier: this.pathModelIdentifier)).toString()
     }
 
+    @Override
     @JsonIgnore
     @Transient
     String getDiffIdentifier() {
         if (parent != null) {return "${parent.getDiffIdentifier()}|${this.pathNodeString}"}
         return pathNodeString
     }
+
+
+    @Override
+    @JsonIgnore
+    @Transient
+    CollectionDiff fromItem() {
+        new BaseCollectionDiff(id, getDiffIdentifier(), label)
+    }
+
+
 
 
 

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/model/Item.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/model/Item.groovy
@@ -1,5 +1,6 @@
 package org.maurodata.domain.model
 
+import jakarta.persistence.PreUpdate
 import org.maurodata.domain.security.CatalogueUser
 
 import com.fasterxml.jackson.annotation.JsonAlias
@@ -44,6 +45,7 @@ abstract class Item implements Serializable, ItemReferencer {
     }
 
     @PrePersist
+    @PreUpdate
     void prePersist() {
         ensureId()
     }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/model/Model.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/model/Model.groovy
@@ -31,7 +31,7 @@ import java.time.Instant
  */
 @CompileStatic
 @Slf4j
-abstract class Model<M extends DiffableItem> extends AdministeredItem implements SecurableResource, ItemReferencer {
+abstract class Model extends AdministeredItem implements DiffableItem, SecurableResource, ItemReferencer {
 
     public static final String DEFAULT_BRANCH_NAME = 'main'
 

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/terminology/CodeSet.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/terminology/CodeSet.groovy
@@ -1,6 +1,10 @@
 package org.maurodata.domain.terminology
 
 import jakarta.persistence.PrePersist
+import jakarta.persistence.PreUpdate
+import org.maurodata.domain.diff.DiffBuilder
+import org.maurodata.domain.diff.DiffableItem
+import org.maurodata.domain.diff.ObjectDiff
 import org.maurodata.domain.model.Item
 import org.maurodata.domain.model.ItemReference
 import org.maurodata.domain.model.ItemReferencer
@@ -32,7 +36,7 @@ import org.maurodata.domain.model.Model
 @MappedEntity(schema = 'terminology')
 @MapConstructor(includeSuperFields = true, includeSuperProperties = true, noArg = true)
 @Indexes([@Index(columns = ['folder_id', 'label', 'branch_name', 'model_version'], unique = true)])
-class CodeSet extends Model implements ItemReferencer {
+class CodeSet extends Model implements ItemReferencer, DiffableItem<CodeSet> {
 
     @Relation(value = Relation.Kind.MANY_TO_MANY, cascade = Relation.Cascade.ALL)
     @JoinTable(
@@ -40,7 +44,6 @@ class CodeSet extends Model implements ItemReferencer {
         joinColumns = @JoinColumn(name = 'code_set_id'),
         inverseJoinColumns = @JoinColumn(name = 'term_id')
     )
-
     Set<Term> terms = []
 
     // This attribute is used when creating a new CodeSet and wanting to add all terms from one or more terminologies.
@@ -84,6 +87,7 @@ class CodeSet extends Model implements ItemReferencer {
     }
 
     @PrePersist
+    @PreUpdate
     void prePersist() {
         super.prePersist()
         if (!getModelWithVersion()) {
@@ -125,6 +129,23 @@ class CodeSet extends Model implements ItemReferencer {
         CodeSet codeSetShallowCopy = new CodeSet()
         this.copyInto(codeSetShallowCopy)
         return codeSetShallowCopy
+    }
+
+    @Override
+    @JsonIgnore
+    @Transient
+    ObjectDiff<CodeSet> diff(CodeSet other, String lhsPathRoot, String rhsPathRoot) {
+        ObjectDiff<CodeSet> base = DiffBuilder.objectDiff(CodeSet)
+            .leftHandSide(id?.toString(), this)
+            .rightHandSide(other.id?.toString(), other)
+        base.label = this.label
+        base.appendString(DiffBuilder.DESCRIPTION, this.description, other.description, this, other)
+        base.appendString(DiffBuilder.ALIASES_STRING, this.aliasesString, other.aliasesString, this, other)
+        if (!DiffBuilder.isNullOrEmpty(this.terms as Collection<Object>) || !DiffBuilder.isNullOrEmpty(other.terms as Collection<Object>)) {
+            base.appendCollection(DiffBuilder.TERMS, this.terms as Collection<DiffableItem>, other.terms as Collection<DiffableItem>, lhsPathRoot,
+                                  rhsPathRoot)
+        }
+        base
     }
 
     /**

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/terminology/Term.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/terminology/Term.groovy
@@ -1,6 +1,8 @@
 package org.maurodata.domain.terminology
 
-
+import org.maurodata.domain.diff.DiffBuilder
+import org.maurodata.domain.diff.DiffableItem
+import org.maurodata.domain.diff.ObjectDiff
 import org.maurodata.domain.model.Item
 import org.maurodata.domain.model.ItemReference
 import org.maurodata.domain.model.ItemReferencer
@@ -20,7 +22,6 @@ import io.micronaut.data.annotation.MappedEntity
 import io.micronaut.data.annotation.Relation
 import jakarta.persistence.Transient
 import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.Pattern
 import org.maurodata.domain.model.AdministeredItem
 import org.maurodata.domain.model.ModelItem
 
@@ -38,7 +39,7 @@ import org.maurodata.domain.model.ModelItem
 @MappedEntity(schema = 'terminology')
 @MapConstructor(includeSuperFields = true, includeSuperProperties = true, noArg = true)
 @Indexes([@Index(columns = ['terminology_id', 'code'], unique = true)])
-class Term extends ModelItem<Terminology> implements ItemReferencer {
+class Term extends ModelItem<Terminology> implements ItemReferencer, DiffableItem<Term> {
 
     @Override
     String getLabel() {
@@ -115,6 +116,41 @@ class Term extends ModelItem<Terminology> implements ItemReferencer {
     @JsonProperty('model')
     UUID getModelId() {
         terminology?.id
+    }
+
+
+    @Override
+    @JsonIgnore
+    @Transient
+    String getDiffIdentifier() {
+        if (terminology != null) {
+            return "${terminology.diffIdentifier}|${getPathNodeString()}"
+        }
+        return "${getPathNodeString()}"
+    }
+
+    @Override
+    @JsonIgnore
+    @Transient
+    ObjectDiff<Term> diff(Term other, String lhsPathRoot, String rhsPathRoot) {
+        ObjectDiff<Term> base = DiffBuilder.objectDiff(Term)
+            .leftHandSide(id?.toString(), this)
+            .rightHandSide(other.id?.toString(), other)
+        base.label = this.label
+        base.appendString(DiffBuilder.DESCRIPTION, this.description, other.description, this, other)
+        base.appendString(DiffBuilder.CODE, this.code, other.code, this, other)
+        base.appendString(DiffBuilder.DEFINITION, this.definition, other.definition, this, other)
+        base.appendString(DiffBuilder.URL, this.url, other.url, this, other)
+        base.appendString(DiffBuilder.ALIASES_STRING, this.aliasesString, other.aliasesString, this, other)
+        if (!DiffBuilder.isNullOrEmpty(this.sourceTermRelationships as Collection<Object>) || !DiffBuilder.isNullOrEmpty(other.sourceTermRelationships as Collection<Object>)) {
+            base.appendCollection(DiffBuilder.SOURCE_TERM_RELATIONSHIPS, this.sourceTermRelationships as Collection<DiffableItem>, other.sourceTermRelationships as Collection<DiffableItem>, lhsPathRoot,
+                                  rhsPathRoot)
+        }
+        if (!DiffBuilder.isNullOrEmpty(this.targetTermRelationships as Collection<Object>) || !DiffBuilder.isNullOrEmpty(other.targetTermRelationships as Collection<Object>)) {
+            base.appendCollection(DiffBuilder.TARGET_TERM_RELATIONSHIPS, this.targetTermRelationships as Collection<DiffableItem>, other.targetTermRelationships as Collection<DiffableItem>, lhsPathRoot,
+                                  rhsPathRoot)
+        }
+        base
     }
 
 

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/terminology/TermRelationship.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/terminology/TermRelationship.groovy
@@ -1,5 +1,8 @@
 package org.maurodata.domain.terminology
 
+import org.maurodata.domain.diff.DiffBuilder
+import org.maurodata.domain.diff.DiffableItem
+import org.maurodata.domain.diff.ObjectDiff
 import org.maurodata.domain.model.Item
 import org.maurodata.domain.model.ItemReference
 import org.maurodata.domain.model.ItemReferencer
@@ -37,7 +40,7 @@ import org.maurodata.domain.model.ModelItem
     @Index(columns = ['source_term_id']),
     @Index(columns = ['target_term_id']),
     @Index(columns = ['relationship_type_id'])])
-class TermRelationship extends ModelItem<Terminology> implements ItemReferencer {
+class TermRelationship extends ModelItem<Terminology> implements ItemReferencer, DiffableItem<TermRelationship> {
 
     @JsonIgnore
     Terminology terminology
@@ -165,4 +168,17 @@ class TermRelationship extends ModelItem<Terminology> implements ItemReferencer 
         this.copyInto(termRelationshipShallowCopy)
         return termRelationshipShallowCopy
     }
+
+    @Override
+    @JsonIgnore
+    @Transient
+    ObjectDiff<TermRelationship> diff(TermRelationship other, String lhsPathRoot, String rhsPathRoot) {
+        ObjectDiff<TermRelationship> base = DiffBuilder.objectDiff(TermRelationship)
+            .leftHandSide(id?.toString(), this)
+            .rightHandSide(other.id?.toString(), other)
+        base.label = this.label
+        base.appendString(DiffBuilder.DESCRIPTION, this.description, other.description, this, other)
+        base
+    }
+
 }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/terminology/TermRelationshipType.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/terminology/TermRelationshipType.groovy
@@ -1,5 +1,8 @@
 package org.maurodata.domain.terminology
 
+import org.maurodata.domain.diff.DiffBuilder
+import org.maurodata.domain.diff.DiffableItem
+import org.maurodata.domain.diff.ObjectDiff
 import org.maurodata.domain.model.Item
 import org.maurodata.domain.model.ItemReference
 import org.maurodata.domain.model.ItemReferencer
@@ -35,7 +38,7 @@ import org.maurodata.domain.model.ModelItem
 @MappedEntity(schema = 'terminology')
 @MapConstructor(includeSuperFields = true, includeSuperProperties = true, noArg = true)
 @Indexes([@Index(columns = ['terminology_id', 'label'], unique = true)])
-class TermRelationshipType extends ModelItem<Terminology> implements ItemReferencer {
+class TermRelationshipType extends ModelItem<Terminology> implements ItemReferencer, DiffableItem<TermRelationshipType> {
 
     @JsonIgnore
     Terminology terminology
@@ -152,5 +155,17 @@ class TermRelationshipType extends ModelItem<Terminology> implements ItemReferen
         TermRelationshipType termRelationshipTypeShallowCopy = new TermRelationshipType()
         this.copyInto(termRelationshipTypeShallowCopy)
         return termRelationshipTypeShallowCopy
+    }
+
+    @Override
+    @JsonIgnore
+    @Transient
+    ObjectDiff<TermRelationshipType> diff(TermRelationshipType other, String lhsPathRoot, String rhsPathRoot) {
+        ObjectDiff<TermRelationshipType> base = DiffBuilder.objectDiff(TermRelationshipType)
+            .leftHandSide(id?.toString(), this)
+            .rightHandSide(other.id?.toString(), other)
+        base.label = this.label
+        base.appendString(DiffBuilder.DESCRIPTION, this.description, other.description, this, other)
+        base
     }
 }

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/terminology/Terminology.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/terminology/Terminology.groovy
@@ -1,6 +1,10 @@
 package org.maurodata.domain.terminology
 
 import jakarta.persistence.PrePersist
+import jakarta.persistence.PreUpdate
+import org.maurodata.domain.diff.DiffBuilder
+import org.maurodata.domain.diff.DiffableItem
+import org.maurodata.domain.diff.ObjectDiff
 import org.maurodata.domain.model.Item
 import org.maurodata.domain.model.ItemReference
 import org.maurodata.domain.model.ItemReferencer
@@ -36,7 +40,7 @@ import org.maurodata.domain.model.ModelItem
 @MapConstructor(includeSuperFields = true, includeSuperProperties = true, noArg = true)
 @Indexes([@Index(columns = ['folder_id', 'label', 'branch_name', 'model_version'], unique = true)])
 @JsonPropertyOrder(['terms', 'termRelationshipTypes'])
-class Terminology extends Model implements ItemReferencer {
+class Terminology extends Model implements ItemReferencer, DiffableItem<Terminology> {
 
     @Relation(value = Relation.Kind.ONE_TO_MANY, mappedBy = 'terminology')
     @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator, property = 'code', scope = Term, resolver = DedupingObjectIdResolver)
@@ -100,11 +104,37 @@ class Terminology extends Model implements ItemReferencer {
     }
 
     @PrePersist
+    @PreUpdate
     void prePersist() {
         super.prePersist()
         if (!getModelWithVersion()) {
             branchName = 'main'
         }
+    }
+
+    @Override
+    @JsonIgnore
+    @Transient
+    ObjectDiff<Terminology> diff(Terminology other, String lhsPathRoot, String rhsPathRoot) {
+        ObjectDiff<Terminology> base = DiffBuilder.objectDiff(Terminology)
+            .leftHandSide(id?.toString(), this)
+            .rightHandSide(other.id?.toString(), other)
+        base.label = this.label
+        base.appendString(DiffBuilder.DESCRIPTION, this.description, other.description, this, other)
+        base.appendString(DiffBuilder.ALIASES_STRING, this.aliasesString, other.aliasesString, this, other)
+        if (!DiffBuilder.isNullOrEmpty(this.terms as Collection<Object>) || !DiffBuilder.isNullOrEmpty(other.terms as Collection<Object>)) {
+            base.appendCollection(DiffBuilder.TERMS, this.terms as Collection<DiffableItem>, other.terms as Collection<DiffableItem>, lhsPathRoot,
+                                  rhsPathRoot)
+        }
+        if (!DiffBuilder.isNullOrEmpty(this.termRelationshipTypes as Collection<Object>) || !DiffBuilder.isNullOrEmpty(other.termRelationshipTypes as Collection<Object>)) {
+            base.appendCollection(DiffBuilder.TERM_RELATIONSHIP_TYPES, this.termRelationshipTypes as Collection<DiffableItem>, other.termRelationshipTypes as Collection<DiffableItem>, lhsPathRoot,
+                                  rhsPathRoot)
+        }
+        if (!DiffBuilder.isNullOrEmpty(this.termRelationships as Collection<Object>) || !DiffBuilder.isNullOrEmpty(other.termRelationships as Collection<Object>)) {
+            base.appendCollection(DiffBuilder.TERM_RELATIONSHIPS, this.termRelationships as Collection<DiffableItem>, other.termRelationships as Collection<DiffableItem>, lhsPathRoot,
+                                  rhsPathRoot)
+        }
+        base
     }
 
 

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/ContentHandler.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/ContentHandler.groovy
@@ -267,18 +267,29 @@ class ContentHandler {
         inBatches(ensureIdsAndSort(termRelationships.findAll {!it.id}), batchSize) {List<TermRelationship> batches ->
             termRelationshipCacheableRepository.saveAll(batches)
         }
-        inBatches(ensureIdsAndSort(codeSets.findAll {!it.id}), batchSize) {List<CodeSet> batches ->
-            codeSetCacheableRepository.saveAll(batches)
+
+        codeSets.findAll {!it.id}.each {
+            try{
+                codeSetCacheableRepository.save(it)
+            } catch(Exception e) {
+                e.printStackTrace()
+            }
         }
+//        inBatches(ensureIdsAndSort(codeSets.findAll {!it.id}), batchSize) {List<CodeSet> batches ->
+//            try{
+//                codeSetCacheableRepository.saveAll(batches)
+//            } catch(Exception e) {
+//                e.printStackTrace()
+//            }
+//        }
 
         // TODO: Improve this by doing them in bulk
         // Actually maybe this happens automatically
-        /*        codeSets.each {codeSet ->
-                    codeSet.terms.each {term ->
-                        codeSetCacheableRepository.addTerm(codeSet.id, term.id)
-                    }
-                }
-        */
+        //codeSets.each {codeSet ->
+//            codeSet.terms.each {term ->
+//                codeSetCacheableRepository.addTerm(codeSet.id, term.id)
+//            }
+//        }
         inBatches(ensureIdsAndSort(dataModels.findAll {!it.id}), batchSize) {List<DataModel> batches ->
             dataModelCacheableRepository.saveAll(batches)
         }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/cache/ModelCacheableRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/cache/ModelCacheableRepository.groovy
@@ -68,6 +68,10 @@ class ModelCacheableRepository<M extends Model> extends AdministeredItemCacheabl
         repository.readByLabelAndModelVersion(label, modelVersion)
     }
 
+    List<M> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier) {
+        repository.findAllByParentAndPathIdentifier(item,  pathIdentifier)
+    }
+
     // Cacheable Model Repository definitions
 
     @CompileStatic

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/classifier/dto/ClassifierDTORepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/classifier/dto/ClassifierDTORepository.groovy
@@ -21,7 +21,7 @@ abstract class ClassifierDTORepository implements GenericRepository<ClassifierDT
     abstract ClassifierDTO findById(UUID id)
 
     @Nullable
-    @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
+    //@Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
     @Query('''select * from core.classifier where label = :pathIdentifier AND ((parent_classifier_id IS NOT NULL AND parent_classifier_id = :item) OR (parent_classifier_id IS NULL AND classification_scheme_id = :item))''')
     abstract List<Classifier> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier)
 

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/dataflow/dto/DataClassComponentDTORepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/dataflow/dto/DataClassComponentDTORepository.groovy
@@ -26,10 +26,10 @@ abstract class DataClassComponentDTORepository implements GenericRepository<Data
     @Nullable
     abstract List<DataClassComponentDTO> findAllByDataFlowId(UUID uuid)
 
-    @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
-    @Join(value = 'dataFlow', type = Join.Type.LEFT_FETCH)
-    @Join(value = 'sourceDataClasses', type = Join.Type.LEFT_FETCH)
-    @Join(value = 'targetDataClasses', type = Join.Type.LEFT_FETCH)
+    //@Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
+    //@Join(value = 'dataFlow', type = Join.Type.LEFT_FETCH)
+    //@Join(value = 'sourceDataClasses', type = Join.Type.LEFT_FETCH)
+    //@Join(value = 'targetDataClasses', type = Join.Type.LEFT_FETCH)
     @Nullable
     @Query('SELECT * FROM dataflow.data_class_component WHERE data_flow_id = :item AND label = :pathIdentifier')
     abstract List<DataClassComponentDTO> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier)

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/dataflow/dto/DataElementComponentDTORepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/dataflow/dto/DataElementComponentDTORepository.groovy
@@ -30,10 +30,10 @@ abstract class DataElementComponentDTORepository implements GenericRepository<Da
     @Nullable
     abstract DataElementComponentDTO findById(UUID id)
 
-    @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
-    @Join(value = 'dataClassComponent', type = Join.Type.LEFT_FETCH)
-    @Join(value = 'sourceDataElements', type = Join.Type.LEFT_FETCH)
-    @Join(value = 'targetDataElements', type = Join.Type.LEFT_FETCH)
+    //@Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
+    //@Join(value = 'dataClassComponent', type = Join.Type.LEFT_FETCH)
+    //@Join(value = 'sourceDataElements', type = Join.Type.LEFT_FETCH)
+    //@Join(value = 'targetDataElements', type = Join.Type.LEFT_FETCH)
     @Nullable
     @Query('SELECT * FROM dataflow.data_element_component WHERE data_class_component_id = :item AND label = :pathIdentifier')
     abstract List<DataElementComponent> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier)

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/dataflow/dto/DataFlowDTORepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/dataflow/dto/DataFlowDTORepository.groovy
@@ -31,9 +31,9 @@ abstract class DataFlowDTORepository implements GenericRepository<DataFlowDTO, U
     @Join(value = 'target', type = Join.Type.LEFT_FETCH)
     abstract List<DataFlowDTO> findAllBySource(DataModel source)
 
-    @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
-    @Join(value = 'source', type = Join.Type.LEFT_FETCH)
-    @Join(value = 'target', type = Join.Type.LEFT_FETCH)
+    //@Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
+    //@Join(value = 'source', type = Join.Type.LEFT_FETCH)
+    //@Join(value = 'target', type = Join.Type.LEFT_FETCH)
     @Query('SELECT * FROM dataflow.data_flow WHERE target_id = :item AND label = :pathIdentifier')
     abstract List<DataFlow> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier)
 

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/DataModelRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/DataModelRepository.groovy
@@ -33,13 +33,13 @@ abstract class DataModelRepository implements ModelRepository<DataModel> {
 
     @Nullable
     List<DataModel> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier) {
-        dataModelDTORepository.findAllByParentAndPathIdentifier(item, pathIdentifier) as List<DataModel>
+        dataModelDTORepository.findAllByParentAndPathIdentifier(item, pathIdentifier)
     }
 
     @Nullable
     @Override
     List<DataModel> findAllByLabel(String pathIdentifier) {
-        dataModelDTORepository.findAllByLabel(pathIdentifier)
+        dataModelDTORepository.findAllByLabel(pathIdentifier) as List<DataModel>
     }
     @Override
     Class getDomainClass() {

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/dto/DataModelDTORepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/dto/DataModelDTORepository.groovy
@@ -19,8 +19,8 @@ abstract class DataModelDTORepository implements GenericRepository<DataModelDTO,
     @Nullable
     abstract DataModelDTO findById(UUID id)
 
-    @Join(value = 'authority', type = Join.Type.LEFT_FETCH)
-    @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
+    //@Join(value = 'authority', type = Join.Type.LEFT_FETCH)
+    //@Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
     @Nullable
     @Query('SELECT * FROM datamodel.data_model WHERE folder_id = :item AND label = :pathIdentifier')
     abstract List<DataModel> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier)

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/dto/EnumerationValueDTORepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/datamodel/dto/EnumerationValueDTORepository.groovy
@@ -27,7 +27,7 @@ abstract class EnumerationValueDTORepository implements GenericRepository<Enumer
     @Nullable
     abstract Set<EnumerationValueDTO> findAllByEnumerationTypeIn(Collection<DataType> dataTypes)
 
-    @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
+    //@Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
     @Nullable
     @Query('SELECT * FROM datamodel.enumeration_value WHERE enumeration_type_id = :item AND label = :pathIdentifier')
     abstract List<EnumerationValue> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier)

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/folder/FolderRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/folder/FolderRepository.groovy
@@ -33,6 +33,7 @@ abstract class FolderRepository implements ModelRepository<Folder> {
     }
 
     @Nullable
+    @Override
     List<Folder> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier) {
         folderDTORepository.findAllByParentAndPathIdentifier(item, pathIdentifier) as List<Folder>
     }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/folder/dto/FolderDTORepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/folder/dto/FolderDTORepository.groovy
@@ -20,12 +20,12 @@ abstract class FolderDTORepository implements GenericRepository<FolderDTO, UUID>
     @Nullable
     abstract FolderDTO findById(UUID id)
 
-    @Join(value = 'authority', type = Join.Type.LEFT_FETCH)
-    @Join(value = 'childFolders', type = Join.Type.LEFT_FETCH)
-    @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
+    //@Join(value = 'authority', type = Join.Type.LEFT_FETCH)
+    //@Join(value = 'childFolders', type = Join.Type.LEFT_FETCH)
+    //@Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
     @Nullable
     @Query('SELECT * FROM core.folder WHERE parent_folder_id = :item AND label = :pathIdentifier')
-    abstract List<FolderDTO> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier)
+    abstract List<Folder> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier)
 
     @Nullable
     abstract List<FolderDTO> findAllByParentFolderId(UUID item)

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/model/PathRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/model/PathRepository.groovy
@@ -40,17 +40,17 @@ class PathRepository {
 
     @NonNull
     AdministeredItemRepository getRepository(AdministeredItem item) {
-        cacheableRepositories.find {it.handles(item.class) || it.handles(item.domainType)} ?: administeredItemRepositories.find {it.handles(item.class) || it.handles(item.domainType)}
+        cacheableRepositories.find {it.handles(item.class) || it.handles(item.domainType)}?.repository ?: administeredItemRepositories.find {it.handles(item.class) || it.handles(item.domainType)}
     }
 
     @NonNull
     AdministeredItemRepository getRepositoryForPathPrefix(final String prefix) {
-        cacheableRepositories.find {it.handlesPathPrefix(prefix)} ?: administeredItemRepositories.find {it.handlesPathPrefix(prefix)}
+        cacheableRepositories.find {it.handlesPathPrefix(prefix)}?.repository ?: administeredItemRepositories.find {it.handlesPathPrefix(prefix)}
     }
 
     @NonNull
     AdministeredItemRepository getRepositoryForDomainType(final String domainType) {
-        cacheableRepositories.find {it.handles(domainType)} ?: administeredItemRepositories.find {it.handles(domainType)}
+        cacheableRepositories.find {it.handles(domainType)}?.repository ?: administeredItemRepositories.find {it.handles(domainType)}
     }
 
     AdministeredItem findResourcesByPathFromRootResource(final AdministeredItem resource, final Path path) {
@@ -76,19 +76,22 @@ class PathRepository {
         return findResourcesByPathFromRootResource(currentAdministeredItem, path, positionInPath + 1)
     }
 
-    List<Path> resolveItemReferences(final List<ItemReference> itemReferences) {
-        final List<Path> resolved = []
+    Map<Path, ItemReference> resolveItemReferences(final List<ItemReference> itemReferences) {
+        final Map<Path, ItemReference> resolved = [:]
         itemReferences.forEach {ItemReference itemReference ->
 
             if (itemReference.pathToItem != null) {
-                resolved << itemReference.pathToItem
+                resolved.put(itemReference.pathToItem, itemReference)
             } else {
                 final AdministeredItemRepository administeredItemRepository = getRepositoryForDomainType(itemReference.itemDomainType)
-                final AdministeredItem resolvedAdministeredItem = (AdministeredItem) administeredItemRepository.findById(itemReference.itemId)
-                if (resolvedAdministeredItem == null) {throw new MauroInternalException("Did not find reference to ${itemReference}")}
-                readParentItems(resolvedAdministeredItem)
-                resolvedAdministeredItem.updatePath()
-                resolved << resolvedAdministeredItem.getPathToEdge()
+                if(administeredItemRepository) { // Otherwise we're just an itemn
+                    final AdministeredItem resolvedAdministeredItem = (AdministeredItem) administeredItemRepository.findById(itemReference.itemId)
+                    if (resolvedAdministeredItem == null) {throw new MauroInternalException("Did not find reference to ${itemReference}")}
+                    readParentItems(resolvedAdministeredItem)
+                    resolvedAdministeredItem.updatePath()
+                    resolved.put(resolvedAdministeredItem.getPathToEdge(), itemReference)
+                    //resolved << resolvedAdministeredItem.getPathToEdge()
+                }
             }
         }
         return resolved

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/security/CatalogueUserRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/security/CatalogueUserRepository.groovy
@@ -5,6 +5,7 @@ import io.micronaut.core.annotation.Nullable
 import io.micronaut.data.annotation.Query
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
+import org.maurodata.FieldConstants
 import org.maurodata.domain.security.CatalogueUser
 import org.maurodata.persistence.model.ItemRepository
 

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/dto/CodeSetDTORepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/dto/CodeSetDTORepository.groovy
@@ -16,7 +16,7 @@ abstract class CodeSetDTORepository implements GenericRepository<CodeSetDTO, UUI
     @Join(value = 'authority', type = Join.Type.LEFT_FETCH)
     abstract CodeSetDTO findById(UUID id)
 
-    @Join(value = 'authority', type = Join.Type.LEFT_FETCH)
+    //@Join(value = 'authority', type = Join.Type.LEFT_FETCH)
     @Query('SELECT * FROM terminology.code_set WHERE folder_id = :item AND label = :pathIdentifier')
     abstract List<CodeSet> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier)
 

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/dto/TermDTORepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/dto/TermDTORepository.groovy
@@ -28,9 +28,9 @@ abstract class TermDTORepository implements GenericRepository<TermDTO, UUID> {
     @Nullable
     abstract TermDTO findAllByTerminologyAndCode(Terminology terminology, String code)
 
-    @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
+    //@Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
     @Nullable
-    @Query('SELECT * FROM terminology.term WHERE terminology_id = :item AND label = :pathIdentifier')
+    @Query('SELECT * FROM terminology.term WHERE terminology_id = :item AND code = :pathIdentifier')
     abstract List<Term> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier)
 
 

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/dto/TermRelationshipDTORepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/dto/TermRelationshipDTORepository.groovy
@@ -38,10 +38,10 @@ abstract class TermRelationshipDTORepository implements GenericRepository<TermRe
     @Nullable
     abstract List<TermRelationshipDTO> findAllByTerminologyAndSourceTermOrTargetTerm(Terminology terminology, Term sourceTerm, Term targetTerm)
 
-    @Join(value = 'sourceTerm', type = Join.Type.LEFT_FETCH)
-    @Join(value = 'targetTerm', type = Join.Type.LEFT_FETCH)
-    @Join(value = 'relationshipType', type = Join.Type.LEFT_FETCH)
-    @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
+    //@Join(value = 'sourceTerm', type = Join.Type.LEFT_FETCH)
+    //@Join(value = 'targetTerm', type = Join.Type.LEFT_FETCH)
+    //@Join(value = 'relationshipType', type = Join.Type.LEFT_FETCH)
+    //@Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
     @Nullable
     @Query('SELECT * FROM terminology.term_relationship WHERE target_term_id = :item AND label = :pathIdentifier')
     abstract List<TermRelationship> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier)

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/dto/TermRelationshipTypeDTORepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/dto/TermRelationshipTypeDTORepository.groovy
@@ -23,7 +23,7 @@ abstract class TermRelationshipTypeDTORepository implements GenericRepository<Te
     @Nullable
     abstract List<TermRelationshipTypeDTO> findAllByTerminology(Terminology terminology)
 
-    @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
+    //@Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
     @Nullable
     @Query('SELECT * FROM terminology.term_relationship_type WHERE terminology_id = :item AND label = :pathIdentifier')
     abstract List<TermRelationshipType> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier)

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/dto/TerminologyDTORepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/terminology/dto/TerminologyDTORepository.groovy
@@ -19,8 +19,8 @@ abstract class TerminologyDTORepository implements GenericRepository<Terminology
     @Nullable
     abstract TerminologyDTO findById(UUID id)
 
-    @Join(value = 'authority', type = Join.Type.LEFT_FETCH)
-    @Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
+    //@Join(value = 'authority', type = Join.Type.LEFT_FETCH)
+    //@Join(value = 'catalogueUser', type = Join.Type.LEFT_FETCH)
     @Nullable
     @Query('SELECT * FROM terminology.terminology WHERE folder_id = :item AND label = :pathIdentifier')
     abstract List<Terminology> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier)


### PR DESCRIPTION
Includes:
- Fixes 'findAllByParentAndPathIdentifier' methods which were not joining correctly.
- Fixes @PrePersist methods to also run at @PreUpdate

I don't think this is yet definitive - more testing required