### PR TITLE
Various fixes around editing datatypes

### DIFF
--- a/mauro-api/src/main/groovy/org/maurodata/controller/datamodel/DataTypeController.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/controller/datamodel/DataTypeController.groovy
@@ -3,6 +3,7 @@ package org.maurodata.controller.datamodel
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import org.maurodata.domain.datamodel.DataElement
+import org.maurodata.domain.datamodel.EnumerationValue
 import org.maurodata.domain.model.Path
 import org.maurodata.persistence.cache.ModelCacheableRepository
 
@@ -92,7 +93,18 @@ class DataTypeController extends AdministeredItemController<DataType, DataModel>
     @Post(Paths.DATA_TYPE_LIST)
     @Transactional
     DataType create(UUID dataModelId, @Body @NonNull DataType dataType) {
+        DataModel dataModel = dataModelRepository.findById(dataModelId)
+        ErrorHandler.handleErrorOnNullObject(HttpStatus.NOT_FOUND, dataModel, "DataModel with id ${dataModelId} not found")
+        accessControlService.checkRole(Role.EDITOR, dataModel)
 
+        // Pull out the enumeration values for saving separately as they require the dataType to be saved first
+
+        List<EnumerationValue> enumerationValues = []
+        if(dataType.enumerationValues)
+        {
+            enumerationValues.addAll(dataType.enumerationValues)
+            dataType.enumerationValues = []
+        }
         DataType cleanItem = super.cleanBody(dataType) as DataType
         Item parent = super.validate(cleanItem, dataModelId)
         cleanItem = dataTypeService.validateDataType(cleanItem, parent)
@@ -147,9 +159,9 @@ class DataTypeController extends AdministeredItemController<DataType, DataModel>
         DataType created = super.createEntity(parent, cleanItem) as DataType
         created = super.validateAndAddClassifiers(created) as DataType
 
-        if (dataType.enumerationValues) {
-            dataType.enumerationValues.each {enumValue ->
-                enumValue.enumerationType = (DataType) dataType
+        if (enumerationValues) {
+            enumerationValues.each {enumValue ->
+                enumValue.enumerationType = dataType
                 enumerationValueRepository.save(enumValue)
             }
         }

--- a/mauro-api/src/main/groovy/org/maurodata/controller/datamodel/EnumerationValueController.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/controller/datamodel/EnumerationValueController.groovy
@@ -49,14 +49,14 @@ class EnumerationValueController extends AdministeredItemController<EnumerationV
 
     @Audit
     @Operation(operationId = 'showEnumerationValue', summary = "Get an enumeration value", description = "Returns an enumeration value.")
-    @Get(Paths.ENUMERATION_VALUE_ID)
+    @Get(uris = [Paths.ENUMERATION_VALUE_ID, Paths.ENUMERATION_VALUE_ID_LEGACY])
     EnumerationValue show(UUID dataModelId, UUID enumerationTypeId, UUID id) {
         super.show(id)
     }
 
     @Audit
     @Operation(operationId = 'createEnumerationValue', summary = "Create an enumeration value", description = "Creates an enumeration value. You must have edit privileges on the item in question.")
-    @Post(Paths.ENUMERATION_VALUE_LIST)
+    @Post(uris = [Paths.ENUMERATION_VALUE_LIST, Paths.ENUMERATION_VALUE_LIST_LEGACY])
     EnumerationValue create(UUID dataModelId, UUID enumerationTypeId, @Body @NonNull EnumerationValue enumerationValue) {
         cleanBody(enumerationValue)
         DataType dataType = dataTypeRepository.readById(enumerationTypeId)
@@ -68,7 +68,7 @@ class EnumerationValueController extends AdministeredItemController<EnumerationV
 
     @Audit
     @Operation(operationId = 'updateEnumerationValue', summary = "Update an enumeration value", description = "Updates an enumeration value.")
-    @Put(Paths.ENUMERATION_VALUE_ID)
+    @Put(uris = [Paths.ENUMERATION_VALUE_ID, Paths.ENUMERATION_VALUE_ID_LEGACY])
     EnumerationValue update(UUID dataModelId, UUID enumerationTypeId, UUID id, @Body @NonNull EnumerationValue enumerationValue) {
         super.update(id, enumerationValue)
     }
@@ -80,14 +80,14 @@ class EnumerationValueController extends AdministeredItemController<EnumerationV
     )
     @ApiResponse(responseCode = "204", description = "No content - deleted successfully")
     @Operation(operationId = 'deleteEnumerationValue', summary = "Delete an enumeration value", description = "Deletes an enumeration value.")
-    @Delete(Paths.ENUMERATION_VALUE_ID)
+    @Delete(uris = [Paths.ENUMERATION_VALUE_ID, Paths.ENUMERATION_VALUE_ID_LEGACY])
     HttpResponse delete(UUID dataModelId, UUID enumerationTypeId, UUID id, @Body @Nullable EnumerationValue enumerationValue) {
         super.delete(id, enumerationValue)
     }
 
     @Audit
     @Operation(operationId = 'listEnumerationValuePaged', summary = "List the enumeration values", description = "Returns the enumeration values. You must have edit privileges on the item in question.")
-    @Get(Paths.ENUMERATION_VALUE_LIST_PAGED)
+    @Get(uris=[Paths.ENUMERATION_VALUE_LIST_PAGED, Paths.ENUMERATION_VALUE_LIST_PAGED_LEGACY])
     ListResponse<EnumerationValue> list(UUID dataModelId, UUID enumerationTypeId, @Nullable PaginationParams params = new PaginationParams()) {
         
         DataType enumerationType = dataTypeRepository.readById(enumerationTypeId)

--- a/mauro-client/src/main/groovy/org/maurodata/api/Paths.groovy
+++ b/mauro-client/src/main/groovy/org/maurodata/api/Paths.groovy
@@ -181,6 +181,10 @@ interface Paths {
     String ENUMERATION_VALUE_ID = '/api/dataModels/{dataModelId}/dataTypes/{enumerationTypeId}/enumerationValues/{id}'
     String ENUMERATION_VALUE_LIST_PAGED = '/api/dataModels/{dataModelId}/dataTypes/{enumerationTypeId}/enumerationValues{?params*}'
 
+    String ENUMERATION_VALUE_LIST_LEGACY = '/api/dataModels/{dataModelId}/enumerationTypes/{enumerationTypeId}/enumerationValues'
+    String ENUMERATION_VALUE_ID_LEGACY = '/api/dataModels/{dataModelId}/enumerationTypes/{enumerationTypeId}/enumerationValues/{id}'
+    String ENUMERATION_VALUE_LIST_PAGED_LEGACY = '/api/dataModels/{dataModelId}/enumerationTypes/{enumerationTypeId}/enumerationValues{?params*}'
+
     /*
     * AnnotationApi
     */

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/ContentHandler.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/ContentHandler.groovy
@@ -805,6 +805,12 @@ class ContentHandler {
         return dataTypes.first()
     }
 
+    EnumerationValue loadWithContent(EnumerationValue enumerationValue) {
+        enumerationValues = [enumerationValue] as Set
+        loadContent()
+        return enumerationValues.first()
+    }
+
     DataElement loadWithContent(DataElement dataElement) {
         dataElements = [dataElement] as Set
         loadContent()


### PR DESCRIPTION
Various fixes around editing datatypes, including:
- Adding security to the method for creating a data type
- Allowing enumeration values to be saved when creating a new data type
- Adding some legacy endpoints for enumeration value management