### PR TITLE
Stream-based file uploads for importers

### DIFF
--- a/mauro-api/src/main/groovy/org/maurodata/controller/model/ModelController.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/controller/model/ModelController.groovy
@@ -412,16 +412,19 @@ abstract class ModelController<M extends Model> extends AdministeredItemControll
         ModelImporterPlugin mauroPlugin = mauroPluginService.getPlugin(ModelImporterPlugin, namespace, name, version)
         PluginService.handlePluginNotFound(mauroPlugin, namespace, name)
 
-        ImportParameters importParameters = importerUtils.readFromMultipartFormBody(body, mauroPlugin.importParametersClass())
+        List<ImportParameters> parametersList = importerUtils.readListFromMultipartFormBody(body, mauroPlugin.importParametersClass())
+        ImportParameters firstParameters = parametersList.first()
 
         Folder folder = null
-        if (importParameters.folderId != null) {
-            folder = folderRepository.readById(importParameters.folderId)
-        } else if( !(mauroPlugin instanceof FolderImporterPlugin)) { // folderId is null and plugin is not a folder import
-            ErrorHandler.handleErrorOnNullObject(HttpStatus.NOT_FOUND, importParameters.folderId, "Please choose the folder into which the Model/s should be imported.")
+        if (firstParameters.folderId != null) {
+            folder = folderRepository.readById(firstParameters.folderId)
+        } else if (!(mauroPlugin instanceof FolderImporterPlugin)) {
+            // folderId is null and plugin is not a folder import
+            ErrorHandler
+                .handleErrorOnNullObject(HttpStatus.UNPROCESSABLE_ENTITY, firstParameters.folderId, "Please choose the folder into which the Model/s should be imported.")
         }
 
-        List<M> imported = (List<M>) mauroPlugin.importModels(importParameters)
+        List<M> imported = (List<M>) mauroPlugin.importModels(parametersList)
 
         accessControlService.checkRole(Role.EDITOR, folder)
         List<M> saved = imported.collect { M imp ->

--- a/mauro-api/src/main/groovy/org/maurodata/service/dataflow/DataflowService.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/service/dataflow/DataflowService.groovy
@@ -4,7 +4,6 @@ import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.http.HttpStatus
-import io.micronaut.http.annotation.Body
 import io.micronaut.http.server.multipart.MultipartBody
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
@@ -24,7 +23,6 @@ import org.maurodata.persistence.cache.ModelCacheableRepository
 import org.maurodata.plugin.MauroPluginService
 import org.maurodata.plugin.exporter.ModelItemExporterPlugin
 import org.maurodata.plugin.importer.DataFlowFileImportParameters
-import org.maurodata.plugin.importer.ImportParameters
 import org.maurodata.plugin.importer.ModelItemImporterPlugin
 import org.maurodata.security.AccessControlService
 import org.maurodata.service.core.AdministeredItemService
@@ -65,33 +63,34 @@ class DataflowService extends AdministeredItemService {
         mauroPlugin
     }
 
-    List<ModelItem> importModelItem(Class aClazz, DataModel target, @Body MultipartBody body, String namespace, String name, @Nullable String version) {
+    List<ModelItem> importModelItem(Class aClazz, DataModel target, MultipartBody body, String namespace, String name, @Nullable String version) {
         ModelItemImporterPlugin mauroPlugin = mauroPluginService.getPlugin(aClazz, namespace, name, version) as ModelItemImporterPlugin
         PluginService.handlePluginNotFound(mauroPlugin, namespace, name)
 
-        DataFlowFileImportParameters importParameters = (DataFlowFileImportParameters) importerUtils.readFromMultipartFormBody(body as MultipartBody, mauroPlugin.importParametersClass())
+        List<DataFlowFileImportParameters> parametersList = importerUtils.readListFromMultipartFormBody(body, DataFlowFileImportParameters)
+        DataFlowFileImportParameters firstParameters = parametersList.first()
 
-        if (importParameters.folderId == null) {
-            ErrorHandler.handleErrorOnNullObject(HttpStatus.NOT_FOUND, importParameters.folderId, "Please choose the folder into which the Model/s should be imported.")
+        if (firstParameters.folderId == null) {
+            ErrorHandler.handleErrorOnNullObject(HttpStatus.UNPROCESSABLE_ENTITY, firstParameters.folderId, "Please choose the folder into which the Model/s should be imported.")
         }
-        if (importParameters.sourceDataModelId == null) {
-            ErrorHandler.handleErrorOnNullObject(HttpStatus.NOT_FOUND, importParameters.sourceDataModelId,
+        if (firstParameters.sourceDataModelId == null) {
+            ErrorHandler.handleErrorOnNullObject(HttpStatus.UNPROCESSABLE_ENTITY, firstParameters.sourceDataModelId,
                                                  "Please choose the source dataModel into which the DataFlow ModelItem/s should be imported.")
         }
-        List<ModelItem> imported = (List<ModelItem>) mauroPlugin.importModelItem(importParameters)
+        List<ModelItem> imported = (List<ModelItem>) mauroPlugin.importModelItem(parametersList)
 
         pathRepository.readParentItems(target)
         target.updatePath()
 
-        DataModel source = dataModelRepository.loadWithContent(importParameters.sourceDataModelId)
-        ErrorHandler.handleErrorOnNullObject(HttpStatus.BAD_REQUEST, source, "Datamodel with id $importParameters.sourceDataModelId not found")
+        DataModel source = dataModelRepository.loadWithContent(firstParameters.sourceDataModelId)
+        ErrorHandler.handleErrorOnNullObject(HttpStatus.BAD_REQUEST, source, "Datamodel with id $firstParameters.sourceDataModelId not found")
         accessControlService.checkRole(Role.EDITOR, source)
 
         pathRepository.readParentItems(source)
         source.updatePath()
 
-        Folder folder = folderRepository.readById(importParameters.folderId)
-        ErrorHandler.handleErrorOnNullObject(HttpStatus.NOT_FOUND, folder, "Folder with id $importParameters.folderId not found")
+        Folder folder = folderRepository.readById(firstParameters.folderId)
+        ErrorHandler.handleErrorOnNullObject(HttpStatus.NOT_FOUND, folder, "Folder with id $firstParameters.folderId not found")
         accessControlService.checkRole(Role.EDITOR, folder)
 
         pathRepository.readParentItems(folder)

--- a/mauro-api/src/main/groovy/org/maurodata/service/federation/SubscribedModelService.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/service/federation/SubscribedModelService.groovy
@@ -16,6 +16,7 @@ import org.maurodata.domain.model.Model
 import org.maurodata.importdata.ImportMetadata
 import org.maurodata.persistence.ContentsService
 import org.maurodata.persistence.cache.ItemCacheableRepository.SubscribedModelCacheableRepository
+import org.maurodata.persistence.cache.ModelCacheableRepository
 import org.maurodata.persistence.service.RepositoryService
 import org.maurodata.plugin.MauroPluginService
 import org.maurodata.plugin.exporter.ModelExporterPlugin
@@ -141,8 +142,10 @@ class SubscribedModelService {
     }
 
     void checkModelLabelAndVersionNotAlreadyImported(Model model) {
-        Model existing = repositoryService.modelCacheableRepositories.find {it.domainType == model.domainType}
-            .readByLabelAndModelVersion(model.label, model.modelVersion)
+        ModelCacheableRepository repository = repositoryService.modelCacheableRepositories.find {it.domainType == model.domainType}
+        Model existing = model.modelVersion ?
+            repository.readByLabelAndModelVersion(model.label, model.modelVersion) :
+            repository.readByLabelAndModelVersionIsNull(model.label)
         if (existing != null) {
             ErrorHandler.handleError(HttpStatus.UNPROCESSABLE_ENTITY, "Model already exists with label $model.label and model version $model.modelVersion")
         }
@@ -154,4 +157,3 @@ class SubscribedModelService {
     }
 
 }
-

--- a/mauro-api/src/main/groovy/org/maurodata/utils/importer/ImporterUtils.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/utils/importer/ImporterUtils.groovy
@@ -3,11 +3,20 @@ package org.maurodata.utils.importer
 import com.fasterxml.jackson.databind.ObjectMapper
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.http.HttpRequest
 import io.micronaut.http.multipart.CompletedFileUpload
 import io.micronaut.http.multipart.CompletedPart
+import io.micronaut.http.multipart.StreamingFileUpload
+import io.micronaut.http.server.netty.MicronautHttpData
+import io.micronaut.http.server.netty.NettyHttpRequest
 import io.micronaut.http.server.multipart.MultipartBody
+import io.netty.handler.codec.http.multipart.HttpData
+import io.netty.handler.codec.http.multipart.FileUpload
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
+import io.netty.handler.codec.http.multipart.InterfaceHttpData
+import org.apache.commons.lang3.reflect.FieldUtils
 import org.maurodata.plugin.importer.FileParameter
 import org.maurodata.plugin.importer.ImportParameters
 import reactor.core.publisher.Flux
@@ -22,15 +31,109 @@ class ImporterUtils {
     ObjectMapper objectMapper
 
 
-
     <P extends ImportParameters> P readFromMultipartFormBody(MultipartBody body, Class<P> parametersClass) {
-        Map<String, Object> importMap = Flux.from(body).collectList().block().collectEntries {CompletedPart cp ->
+        readListFromMultipartFormBody(body, parametersClass).first()
+    }
+
+    <P extends ImportParameters> List<P> readListFromMultipartFormBody(MultipartBody body, Class<P> parametersClass) {
+        Map<String, Object> scalarParts = [:]
+        Map<String, List<FileParameter>> fileParts = [:].withDefault {[]}
+
+        Flux.from(body).collectList().block().each {CompletedPart cp ->
             if (cp instanceof CompletedFileUpload) {
-                return [cp.name, new FileParameter(cp.filename, cp.contentType.toString(), cp.bytes)]
+                fileParts[cp.name].add(new FileParameter(cp.filename, cp.contentType.toString(), cp.inputStream))
             } else {
-                return [cp.name, new String(cp.bytes, StandardCharsets.UTF_8)]
+                scalarParts[cp.name] = new String(cp.bytes, StandardCharsets.UTF_8)
             }
         }
-        return objectMapper.convertValue(importMap, parametersClass)
+
+        List<FileParameter> importFiles = fileParts.importFile
+        if (!importFiles || !acceptsImportFile(parametersClass)) {
+            return [objectMapper.convertValue(scalarParts, parametersClass)]
+        }
+
+        importFiles.collect {FileParameter importFile ->
+            P parameters = objectMapper.convertValue(scalarParts, parametersClass)
+            FieldUtils.writeField(parameters, 'importFile', importFile, true)
+            parameters
+        } as List<P>
+    }
+
+    <P extends ImportParameters> List<P> readFromStreamingMultipart(HttpRequest<?> request, Class<P> parametersClass) {
+        readFromStreamingMultipart(request, null as StreamingFileUpload[], parametersClass)
+    }
+
+    <P extends ImportParameters> List<P> readFromStreamingMultipart(HttpRequest<?> request, @Nullable StreamingFileUpload[] importFiles, Class<P> parametersClass) {
+        Map<String, Object> scalarParts = readUnclaimedScalarParts(request)
+        List<FileParameter> fileParameters = readCompletedFileParts(request, 'importFile')
+        if (!fileParameters && importFiles) {
+            fileParameters = importFiles.collect {StreamingFileUpload importFile ->
+                new FileParameter(importFile.filename,
+                                  importFile.contentType.map {it.toString()}.orElse(null),
+                                  importFile.asInputStream())
+            }
+        }
+
+        if (!fileParameters) {
+            return [objectMapper.convertValue(scalarParts, parametersClass)]
+        }
+        if (!acceptsImportFile(parametersClass)) {
+            return [objectMapper.convertValue(scalarParts, parametersClass)]
+        }
+
+        fileParameters.collect {FileParameter importFile ->
+            P parameters = objectMapper.convertValue(scalarParts, parametersClass)
+            FieldUtils.writeField(parameters, 'importFile', importFile, true)
+            parameters
+        } as List<P>
+    }
+
+    protected static Boolean acceptsImportFile(Class<? extends ImportParameters> parametersClass) {
+        FieldUtils.getField(parametersClass, 'importFile', true) != null
+    }
+
+    protected static List<FileParameter> readCompletedFileParts(HttpRequest<?> request, String partName) {
+        if (!(request instanceof NettyHttpRequest) || !(request as NettyHttpRequest).hasFormRouteCompleter()) {
+            return []
+        }
+
+        Set<MicronautHttpData<? extends HttpData>> allData = (Set<MicronautHttpData<? extends HttpData>>) FieldUtils.readField((request as NettyHttpRequest).formRouteCompleter(), 'allData', true)
+        allData.findAll {MicronautHttpData<? extends HttpData> data ->
+            data.name == partName &&
+            data.httpDataType == InterfaceHttpData.HttpDataType.FileUpload &&
+            data.completed
+        }.collect {MicronautHttpData<? extends HttpData> data ->
+            FileUpload fileUpload = data as FileUpload
+            new FileParameter(fileUpload.filename, fileUpload.contentType, data.toStream())
+        } as List<FileParameter>
+    }
+
+    protected static Map<String, Object> readUnclaimedScalarParts(HttpRequest<?> request) {
+        if (!(request instanceof NettyHttpRequest) || !(request as NettyHttpRequest).hasFormRouteCompleter()) {
+            return [:]
+        }
+
+        Set<MicronautHttpData<? extends HttpData>> allData = (Set<MicronautHttpData<? extends HttpData>>) FieldUtils.readField((request as NettyHttpRequest).formRouteCompleter(), 'allData', true)
+        Map<String, Object> scalarParts = [:]
+        Map<String, List<String>> repeatedParts = [:]
+
+        allData.findAll {MicronautHttpData<? extends HttpData> data ->
+            data.name != 'importFile' &&
+            data.httpDataType != InterfaceHttpData.HttpDataType.FileUpload &&
+            data.completed
+        }.each {MicronautHttpData<?> data ->
+            String value = data.getString(StandardCharsets.UTF_8)
+            List<String> repeated = repeatedParts[data.name]
+            if (repeated) {
+                repeated.add(value)
+            } else if (scalarParts.containsKey(data.name)) {
+                repeated = [scalarParts[data.name] as String, value]
+                repeatedParts[data.name] = repeated
+                scalarParts[data.name] = repeated
+            } else {
+                scalarParts[data.name] = value
+            }
+        }
+        scalarParts
     }
 }

--- a/mauro-api/src/test/groovy/org/maurodata/datamodel/DataModelJsonImportExportSpec.groovy
+++ b/mauro-api/src/test/groovy/org/maurodata/datamodel/DataModelJsonImportExportSpec.groovy
@@ -172,4 +172,51 @@ class DataModelJsonImportExportSpec extends CommonDataSpec {
         copiedSummaryMetadataReport.items.size() == 1
         copiedSummaryMetadataReport.items.first().id != summaryMetadataReportId
     }
+
+    void 'import dataModel with zero files'() {
+        given:
+        ZeroFileDataModelImporterPlugin.reset()
+        UUID targetFolderId = folderApi.create(new Folder(label: 'Zero file import folder')).id
+        MultipartBody importRequest = MultipartBody.builder()
+            .addPart('folderId', targetFolderId.toString())
+            .addPart('modelName', 'Imported without file')
+            .build()
+
+        when:
+        ListResponse<DataModel> response =
+            dataModelApi.importModel(
+                importRequest,
+                'org.maurodata.datamodel',
+                'ZeroFileDataModelImporterPlugin',
+                '1.0.0')
+
+        then:
+        response.count == 1
+        response.items.first().label == 'Imported without file'
+        ZeroFileDataModelImporterPlugin.importCount == 1
+    }
+
+    void 'import dataModels with multiple files'() {
+        given:
+        MultiFileDataModelImporterPlugin.reset()
+        UUID targetFolderId = folderApi.create(new Folder(label: 'Multi file import folder')).id
+        MultipartBody importRequest = MultipartBody.builder()
+            .addPart('folderId', targetFolderId.toString())
+            .addPart('importFile', 'one.json', MediaType.APPLICATION_JSON_TYPE, '{}'.bytes)
+            .addPart('importFile', 'two.json', MediaType.APPLICATION_JSON_TYPE, '{}'.bytes)
+            .build()
+
+        when:
+        ListResponse<DataModel> response =
+            dataModelApi.importModel(
+                importRequest,
+                'org.maurodata.datamodel',
+                'MultiFileDataModelImporterPlugin',
+                '1.0.0')
+
+        then:
+        response.count == 2
+        response.items.label as Set == ['Imported one.json', 'Imported two.json'] as Set
+        MultiFileDataModelImporterPlugin.importedFileNames == ['one.json', 'two.json']
+    }
 }

--- a/mauro-api/src/test/groovy/org/maurodata/datamodel/TestDataModelImporters.groovy
+++ b/mauro-api/src/test/groovy/org/maurodata/datamodel/TestDataModelImporters.groovy
@@ -1,0 +1,68 @@
+package org.maurodata.datamodel
+
+import groovy.transform.CompileStatic
+import jakarta.inject.Singleton
+import org.maurodata.domain.datamodel.DataModel
+import org.maurodata.plugin.importer.DataModelImporterPlugin
+import org.maurodata.plugin.importer.FileImportParameters
+import org.maurodata.plugin.importer.ImportParameters
+
+@CompileStatic
+@Singleton
+class ZeroFileDataModelImporterPlugin implements DataModelImporterPlugin<ImportParameters> {
+
+    static Integer importCount = 0
+
+    String version = '1.0.0'
+    String displayName = 'Zero File DataModel Importer'
+
+    static void reset() {
+        importCount = 0
+    }
+
+    @Override
+    List<DataModel> importDomain(ImportParameters params) {
+        importCount++
+        [new DataModel(label: params.modelName ?: 'Zero file data model')]
+    }
+
+    @Override
+    Boolean handlesContentType(String contentType) {
+        false
+    }
+
+    @Override
+    Class<ImportParameters> importParametersClass() {
+        ImportParameters
+    }
+}
+
+@CompileStatic
+@Singleton
+class MultiFileDataModelImporterPlugin implements DataModelImporterPlugin<FileImportParameters> {
+
+    static List<String> importedFileNames = []
+
+    String version = '1.0.0'
+    String displayName = 'Multi File DataModel Importer'
+
+    static void reset() {
+        importedFileNames = []
+    }
+
+    @Override
+    List<DataModel> importDomain(FileImportParameters params) {
+        importedFileNames.add(params.importFile.fileName)
+        [new DataModel(label: "Imported ${params.importFile.fileName}".toString())]
+    }
+
+    @Override
+    Boolean handlesContentType(String contentType) {
+        true
+    }
+
+    @Override
+    Class<FileImportParameters> importParametersClass() {
+        FileImportParameters
+    }
+}

--- a/mauro-api/src/test/groovy/org/maurodata/importexport/DataModelJsonImportExportIntegrationSpec.groovy
+++ b/mauro-api/src/test/groovy/org/maurodata/importexport/DataModelJsonImportExportIntegrationSpec.groovy
@@ -108,9 +108,9 @@ class DataModelJsonImportExportIntegrationSpec extends CommonDataSpec {
 
         and:
         MultipartBody importRequest = MultipartBody.builder()
-                .addPart('folderId', folderId.toString())
-                .addPart('importFile', 'file.json', MediaType.APPLICATION_JSON_TYPE, response.body())
-                .build()
+            .addPart('folderId', folderId.toString())
+            .addPart('importFile', 'file.json', MediaType.APPLICATION_JSON_TYPE, response.body())
+            .build()
         when:
         ListResponse<DataModel> dataModelResponse = dataModelApi.importModel(importRequest, 'org.maurodata.plugin.importer.json', 'JsonDataModelImporterPlugin', '4.0.0')
 
@@ -162,9 +162,9 @@ class DataModelJsonImportExportIntegrationSpec extends CommonDataSpec {
 
 
         MultipartBody importRequest = MultipartBody.builder()
-                .addPart('folderId', folderId.toString())
-                .addPart('importFile', 'file.json', MediaType.APPLICATION_JSON_TYPE, payload)
-                .build()
+            .addPart('folderId', folderId.toString())
+            .addPart('importFile', 'file.json', MediaType.APPLICATION_JSON_TYPE, payload)
+            .build()
 
         ListResponse<DataModel> response = dataModelApi.importModel(importRequest, 'org.maurodata.plugin.importer.json', 'JsonDataModelImporterPlugin', '4.0.0')
         response.items[0].id

--- a/mauro-api/src/test/groovy/org/maurodata/importexport/FolderJsonImportExportIntegrationSpec.groovy
+++ b/mauro-api/src/test/groovy/org/maurodata/importexport/FolderJsonImportExportIntegrationSpec.groovy
@@ -193,9 +193,9 @@ class FolderJsonImportExportIntegrationSpec extends CommonDataSpec {
 
 
         MultipartBody importRequest = MultipartBody.builder()
-                .addPart('folderId', folderId.toString())
-                .addPart('importFile', 'file.json', MediaType.APPLICATION_JSON_TYPE, exportResponse.body())
-                .build()
+            .addPart('folderId', folderId.toString())
+            .addPart('importFile', 'file.json', MediaType.APPLICATION_JSON_TYPE, exportResponse.body())
+            .build()
 
         when:
         ListResponse<Folder> response = folderApi.importModel(importRequest, 'org.maurodata.plugin.importer.json', 'JsonFolderImporterPlugin', '4.0.0')
@@ -361,9 +361,9 @@ class FolderJsonImportExportIntegrationSpec extends CommonDataSpec {
         HttpResponse<byte[]> exportResponse = folderApi.exportModel(folderId, 'org.maurodata.plugin.exporter.json', 'JsonFolderExporterPlugin', '4.0.0')
 
         MultipartBody importRequest = MultipartBody.builder()
-                .addPart('folderId', childFolderId.toString())
-                .addPart('importFile', 'file.json', MediaType.APPLICATION_JSON_TYPE, exportResponse.body())
-                .build()
+            .addPart('folderId', childFolderId.toString())
+            .addPart('importFile', 'file.json', MediaType.APPLICATION_JSON_TYPE, exportResponse.body())
+            .build()
 
         when:
         ListResponse<Folder> response = folderApi.importModel(importRequest, 'org.maurodata.plugin.importer.json', 'JsonFolderImporterPlugin', '4.0.0')

--- a/mauro-api/src/test/groovy/org/maurodata/testing/LowLevelApi.groovy
+++ b/mauro-api/src/test/groovy/org/maurodata/testing/LowLevelApi.groovy
@@ -147,9 +147,9 @@ class LowLevelApi {
             dataModel dataModelToImport
         }
         MultipartBody importRequest = MultipartBody.builder()
-                .addPart('folderId', folder.id.toString())
-                .addPart('importFile', 'file.json', MediaType.APPLICATION_JSON_TYPE, objectMapper.writeValueAsBytes(exportModel))
-                .build()
+            .addPart('folderId', folder.id.toString())
+            .addPart('importFile', 'file.json', MediaType.APPLICATION_JSON_TYPE, objectMapper.writeValueAsBytes(exportModel))
+            .build()
         String namespace = jsonDataModelImporterPlugin.namespace
         String name = jsonDataModelImporterPlugin.name
         String version = jsonDataModelImporterPlugin.version
@@ -163,9 +163,9 @@ class LowLevelApi {
             terminology terminologyToImport
         }
         MultipartBody importRequest = MultipartBody.builder()
-                .addPart('folderId', folder.id.toString())
-                .addPart('importFile', 'file.json', MediaType.APPLICATION_JSON_TYPE, objectMapper.writeValueAsBytes(exportModel))
-                .build()
+            .addPart('folderId', folder.id.toString())
+            .addPart('importFile', 'file.json', MediaType.APPLICATION_JSON_TYPE, objectMapper.writeValueAsBytes(exportModel))
+            .build()
         String namespace = jsonTerminologyImporterPlugin.namespace
         String name = jsonTerminologyImporterPlugin.name
         String version = jsonTerminologyImporterPlugin.version

--- a/mauro-client/src/main/groovy/org/maurodata/ApiClient.groovy
+++ b/mauro-client/src/main/groovy/org/maurodata/ApiClient.groovy
@@ -147,11 +147,8 @@ abstract class ApiClient {
     ListResponse<Folder> importFolder(Folder folder, UUID parentFolderId = null) {
 
         MultipartBody.Builder importRequest = MultipartBody.builder()
+            .tap {if (parentFolderId) it.addPart('folderId', parentFolderId.toString())}
             .addPart('importFile', 'file.json', MediaType.APPLICATION_JSON_TYPE, jsonFolderExporterPlugin.exportModel(folder))
-
-        if(parentFolderId) {
-            importRequest.addPart('folderId', parentFolderId.toString())
-        }
 
         folderApi.importModel(
             importRequest.build(),

--- a/mauro-client/src/main/groovy/org/maurodata/api/classifier/ClassificationSchemeApi.groovy
+++ b/mauro-client/src/main/groovy/org/maurodata/api/classifier/ClassificationSchemeApi.groovy
@@ -19,7 +19,7 @@ import io.micronaut.http.annotation.Delete
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Post
 import io.micronaut.http.annotation.Put
-import io.micronaut.http.server.multipart.MultipartBody
+import io.micronaut.http.client.multipart.MultipartBody
 import io.micronaut.scheduling.TaskExecutors
 import io.micronaut.scheduling.annotation.ExecuteOn
 

--- a/mauro-client/src/main/groovy/org/maurodata/api/dataflow/DataFlowApi.groovy
+++ b/mauro-client/src/main/groovy/org/maurodata/api/dataflow/DataFlowApi.groovy
@@ -60,7 +60,4 @@ interface DataFlowApi extends AdministeredItemApi<DataFlow, DataModel> {
     @Produces(MediaType.MULTIPART_FORM_DATA)
     @Post(Paths.DATA_FLOW_IMPORT)
     ListResponse<DataFlow> importModel(@NonNull UUID dataModelId, @Body MultipartBody body, @Nullable String namespace, @Nullable String name, @Nullable String version)
-
-    // This is the version that will be implemented by the controller
-    ListResponse<DataFlow> importModel(@NonNull UUID dataModelId, @Body io.micronaut.http.server.multipart.MultipartBody body, String namespace, String name, @Nullable String version)
 }

--- a/mauro-client/src/main/groovy/org/maurodata/api/datamodel/DataModelApi.groovy
+++ b/mauro-client/src/main/groovy/org/maurodata/api/datamodel/DataModelApi.groovy
@@ -86,9 +86,6 @@ interface DataModelApi extends ModelApi<DataModel> {
     @Post(Paths.DATA_MODEL_IMPORT)
     ListResponse<DataModel> importModel(@Body MultipartBody body, String namespace, String name, @Nullable String version)
 
-    // This is the version that will be implemented by the controller
-    ListResponse<DataModel> importModel(@Body io.micronaut.http.server.multipart.MultipartBody body, String namespace, String name, @Nullable String version)
-
     @Get(Paths.DATA_MODEL_DIFF)
     ObjectDiff diffModels(@NonNull UUID id, @NonNull UUID otherId)
 

--- a/mauro-client/src/main/groovy/org/maurodata/api/folder/FolderApi.groovy
+++ b/mauro-client/src/main/groovy/org/maurodata/api/folder/FolderApi.groovy
@@ -65,9 +65,6 @@ interface FolderApi extends ModelApi<Folder> {
     @Post(Paths.FOLDER_IMPORT)
     ListResponse<Folder> importModel(@Body MultipartBody body, String namespace, String name, @Nullable String version)
 
-    // This is the version that will be implemented by the controller
-    ListResponse<Folder> importModel(@Body io.micronaut.http.server.multipart.MultipartBody body, String namespace, String name, @Nullable String version)
-
     @Get(Paths.FOLDER_DOI)
     Map doi(UUID id)
 

--- a/mauro-client/src/main/groovy/org/maurodata/api/model/ModelApi.groovy
+++ b/mauro-client/src/main/groovy/org/maurodata/api/model/ModelApi.groovy
@@ -38,9 +38,6 @@ interface ModelApi<M extends Model> extends AdministeredItemApi<M, Folder> {
 
     ListResponse<M> importModel(@Body MultipartBody body, String namespace, String name, @Nullable String version)
 
-    // To be implemented by the controller
-    ListResponse<M> importModel(@Body io.micronaut.http.server.multipart.MultipartBody body, String namespace, String name, @Nullable String version)
-
     M allowReadByAuthenticated(UUID id)
 
     HttpResponse revokeReadByAuthenticated(UUID id)

--- a/mauro-client/src/main/groovy/org/maurodata/api/terminology/CodeSetApi.groovy
+++ b/mauro-client/src/main/groovy/org/maurodata/api/terminology/CodeSetApi.groovy
@@ -1,6 +1,5 @@
 package org.maurodata.api.terminology
 
-import io.micronaut.http.server.multipart.MultipartBody
 import org.maurodata.api.MauroApi
 import org.maurodata.api.Paths
 
@@ -10,7 +9,6 @@ import org.maurodata.domain.model.version.CreateNewVersionData
 import org.maurodata.domain.model.version.FinaliseData
 import org.maurodata.domain.terminology.CodeSet
 import org.maurodata.domain.terminology.Term
-import org.maurodata.domain.terminology.Terminology
 import org.maurodata.web.ListResponse
 import org.maurodata.web.PaginationParams
 
@@ -22,6 +20,7 @@ import io.micronaut.http.annotation.Delete
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Post
 import io.micronaut.http.annotation.Put
+import io.micronaut.http.client.multipart.MultipartBody
 
 @MauroApi
 interface CodeSetApi extends ModelApi<CodeSet> {

--- a/mauro-client/src/main/groovy/org/maurodata/api/terminology/TerminologyApi.groovy
+++ b/mauro-client/src/main/groovy/org/maurodata/api/terminology/TerminologyApi.groovy
@@ -75,10 +75,6 @@ interface TerminologyApi extends ModelApi<Terminology> {
     @Post(Paths.TERMINOLOGY_IMPORT)
     ListResponse<Terminology> importModel(@Body MultipartBody body, String namespace, String name, @Nullable String version)
 
-    // This is the version that will be implemented by the controller
-    ListResponse<Terminology> importModel(@Body io.micronaut.http.server.multipart.MultipartBody body, String namespace, String name, @Nullable String version)
-
-
     /*
     @Transactional
     @Consumes(MediaType.MULTIPART_FORM_DATA)

--- a/mauro-domain/src/main/groovy/org/maurodata/plugin/importer/FileParameter.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/plugin/importer/FileParameter.groovy
@@ -18,6 +18,8 @@
 package org.maurodata.plugin.importer
 
 import groovy.transform.CompileStatic
+import java.io.ByteArrayInputStream
+import java.io.InputStream
 
 /**
  * @since 06/03/2018
@@ -26,6 +28,7 @@ import groovy.transform.CompileStatic
 class FileParameter {
 
     byte[] fileContents
+    InputStream inputStream
     String fileName
     String fileType
     FileParameter() {
@@ -35,23 +38,36 @@ class FileParameter {
     FileParameter(String fileName, String fileType, byte[] fileContents) {
         this.fileName = fileName
         this.fileType = fileType
-        this.fileContents = Arrays.copyOf(fileContents, fileContents.size())
+        this.fileContents = fileContents
+    }
+
+    FileParameter(String fileName, String fileType, InputStream inputStream) {
+        this.fileName = fileName
+        this.fileType = fileType
+        this.inputStream = inputStream
     }
 
     byte[] getFileContents() {
-        Arrays.copyOf(fileContents, fileContents.size())
+        if (fileContents == null && inputStream != null) {
+            fileContents = inputStream.bytes
+            inputStream = null
+        }
+        fileContents
     }
 
     void setFileContents(byte[] fileContents) {
-        this.fileContents = Arrays.copyOf(fileContents, fileContents.size())
+        this.fileContents = fileContents
+        this.inputStream = null
     }
 
-    //void setFileContents(ByteArrayInputStream fileContents) {
-    //    setFileContents(fileContents.readAllBytes())
-    //}
-
     InputStream getInputStream() {
-        new ByteArrayInputStream(fileContents)
+        if (inputStream != null) {
+            return inputStream
+        }
+        if (fileContents != null) {
+            return new ByteArrayInputStream(fileContents)
+        }
+        InputStream.nullInputStream()
     }
 
 

--- a/mauro-domain/src/main/groovy/org/maurodata/plugin/importer/ModelImporterPlugin.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/plugin/importer/ModelImporterPlugin.groovy
@@ -16,6 +16,12 @@ trait ModelImporterPlugin <D extends Model, P extends ImportParameters> extends 
 
     abstract List<D> importDomain(P params)
 
+    List<D> importDomain(List<P> paramsList) {
+        paramsList.collectMany {P params ->
+            importDomain(params)
+        } as List<D>
+    }
+
     Boolean getCanImportMultipleDomains() {
         true
     }
@@ -39,7 +45,11 @@ trait ModelImporterPlugin <D extends Model, P extends ImportParameters> extends 
     }
 
     List<D> importModels(P parameters) {
-        List<D> imported = importDomain(parameters)
+        importModels([parameters])
+    }
+
+    List<D> importModels(List<P> parametersList) {
+        List<D> imported = importDomain(parametersList)
         imported.each { importedModel ->
             importedModel.setAssociations()
             if (importedModel.modelType == Terminology.class.simpleName){

--- a/mauro-domain/src/main/groovy/org/maurodata/plugin/importer/ModelItemImporterPlugin.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/plugin/importer/ModelItemImporterPlugin.groovy
@@ -15,6 +15,12 @@ trait ModelItemImporterPlugin<D extends ModelItem, P extends ImportParameters> e
 
     abstract List<D> importDomain(P params)
 
+    List<D> importDomain(List<P> paramsList) {
+        paramsList.collectMany {P params ->
+            importDomain(params)
+        } as List<D>
+    }
+
     Boolean getCanImportMultipleDomains() {
         true
     }
@@ -38,7 +44,11 @@ trait ModelItemImporterPlugin<D extends ModelItem, P extends ImportParameters> e
     }
 
     List<D> importModelItem(P parameters) {
-        List<D> imported = importDomain(parameters)
+        importModelItem([parameters])
+    }
+
+    List<D> importModelItem(List<P> parametersList) {
+        List<D> imported = importDomain(parametersList)
         imported.each { importedModelItem ->
 
             log.info '* start updateCreationProperties *'

--- a/mauro-domain/src/main/groovy/org/maurodata/plugin/importer/json/JsonCodeSetImporterPlugin.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/plugin/importer/json/JsonCodeSetImporterPlugin.groovy
@@ -30,15 +30,21 @@ class JsonCodeSetImporterPlugin implements CodeSetImporterPlugin<FileImportParam
     @Override
     List<CodeSet> importDomain(FileImportParameters params) {
         log.info '** start importModel **'
-        ExportModel importModel = objectMapper.readValue(params.importFile.fileContents, ExportModel)
-        log.info '*** imported JSON model ***'
-        if (!importModel.codeSet && !importModel.codeSets){
+        long start = System.nanoTime()
+        if (!params.importFile) {
+            ErrorHandler.handleError(HttpStatus.UNPROCESSABLE_ENTITY, 'Import file is required')
+        }
+        ExportModel importModel = params.importFile.inputStream.withCloseable {InputStream inputStream ->
+            objectMapper.readValue(inputStream, ExportModel)
+        }
+        log.info '*** imported JSON model in {} ms ***', (System.nanoTime() - start).intdiv(1000000L)
+        if (!importModel.codeSet && !importModel.codeSets) {
             ErrorHandler.handleError(HttpStatus.BAD_REQUEST, 'Cannot import JSON as codeSet/s not present')
         }
-        if(importModel.codeSet) {
+        if (importModel.codeSet) {
             return [importModel.codeSet]
         } else {
-            return importModel.codeSets?:[]
+            return importModel.codeSets ?: []
         }
 
     }

--- a/mauro-domain/src/main/groovy/org/maurodata/plugin/importer/json/JsonDataFlowImporterPlugin.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/plugin/importer/json/JsonDataFlowImporterPlugin.groovy
@@ -3,8 +3,10 @@ package org.maurodata.plugin.importer.json
 import com.fasterxml.jackson.databind.ObjectMapper
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+import io.micronaut.http.HttpStatus
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
+import org.maurodata.ErrorHandler
 import org.maurodata.domain.dataflow.DataFlow
 import org.maurodata.export.ExportModel
 import org.maurodata.plugin.importer.DataFlowFileImportParameters
@@ -27,13 +29,19 @@ class JsonDataFlowImporterPlugin implements DataFlowImporterPlugin<DataFlowFileI
     @Override
     List<DataFlow> importDomain(DataFlowFileImportParameters params) {
         log.info '** start importModel **'
-        ExportModel importModel = objectMapper.readValue(params.importFile.fileContents, ExportModel)
-        log.info '*** imported JSON model ***'
+        long start = System.nanoTime()
+        if (!params.importFile) {
+            ErrorHandler.handleError(HttpStatus.UNPROCESSABLE_ENTITY, 'Import file is required')
+        }
+        ExportModel importModel = params.importFile.inputStream.withCloseable {InputStream inputStream ->
+            objectMapper.readValue(inputStream, ExportModel)
+        }
+        log.info '*** imported JSON model in {} ms ***', (System.nanoTime() - start).intdiv(1000000L)
 
-        if(importModel.dataFlow) {
+        if (importModel.dataFlow) {
             return [importModel.dataFlow]
         } else {
-            return importModel.dataFlows?:[]
+            return importModel.dataFlows ?: []
         }
 
     }

--- a/mauro-domain/src/main/groovy/org/maurodata/plugin/importer/json/JsonDataModelImporterPlugin.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/plugin/importer/json/JsonDataModelImporterPlugin.groovy
@@ -29,8 +29,14 @@ class JsonDataModelImporterPlugin implements DataModelImporterPlugin<FileImportP
     @Override
     List<DataModel> importDomain(FileImportParameters params) {
         log.info '** start importModel **'
-        ExportModel importModel = objectMapper.readValue(params.importFile.fileContents, ExportModel)
-        log.info '*** imported JSON model ***'
+        long start = System.nanoTime()
+        if (!params.importFile) {
+            ErrorHandler.handleError(HttpStatus.UNPROCESSABLE_ENTITY, 'Import file is required')
+        }
+        ExportModel importModel = params.importFile.inputStream.withCloseable {InputStream inputStream ->
+            objectMapper.readValue(inputStream, ExportModel)
+        }
+        log.info '*** imported JSON model in {} ms ***', (System.nanoTime() - start).intdiv(1000000L)
         if (!importModel.dataModel && !importModel.dataModels) {
             ErrorHandler.handleError(HttpStatus.BAD_REQUEST, 'Cannot import JSON as datamodel/s not present')
         }

--- a/mauro-domain/src/main/groovy/org/maurodata/plugin/importer/json/JsonFolderImporterPlugin.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/plugin/importer/json/JsonFolderImporterPlugin.groovy
@@ -16,6 +16,8 @@ import org.maurodata.plugin.JsonPluginConstants
 import org.maurodata.plugin.importer.FileImportParameters
 import org.maurodata.plugin.importer.FolderImporterPlugin
 
+import java.util.concurrent.TimeUnit
+
 @Slf4j
 @Singleton
 @CompileStatic
@@ -34,11 +36,15 @@ class JsonFolderImporterPlugin implements FolderImporterPlugin<FileImportParamet
     List<Folder> importDomain(FileImportParameters params) {
         log.info '** start importModel **'
 
-        JsonNode importModelTree = objectMapper.readTree(params.importFile.fileContents)
-
-        ExportModel importModel = objectMapper.treeToValue(importModelTree, ExportModel)
-        log.info '*** imported JSON model ***'
-        if (!importModel.folder && !importModel.folders){
+        long start = System.nanoTime()
+        if (!params.importFile) {
+            ErrorHandler.handleError(HttpStatus.UNPROCESSABLE_ENTITY, 'Import file is required')
+        }
+        ExportModel importModel = params.importFile.inputStream.withCloseable {InputStream inputStream ->
+            objectMapper.readValue(inputStream, ExportModel)
+        }
+        log.info '*** imported JSON model in {} ms ***', TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start)
+        if (!importModel.folder && !importModel.folders) {
             ErrorHandler.handleError(HttpStatus.BAD_REQUEST, 'Cannot import JSON as folder/s not present')
         }
         if (importModel.folder) {

--- a/mauro-domain/src/main/groovy/org/maurodata/plugin/importer/json/JsonTerminologyImporterPlugin.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/plugin/importer/json/JsonTerminologyImporterPlugin.groovy
@@ -28,8 +28,14 @@ class JsonTerminologyImporterPlugin implements TerminologyImporterPlugin<FileImp
     @Override
     List<Terminology> importDomain(FileImportParameters params) {
         log.info '** start importModel **'
-        ExportModel importModel = objectMapper.readValue(params.importFile.fileContents, ExportModel)
-        log.info '*** imported JSON model ***'
+        long start = System.nanoTime()
+        if (!params.importFile) {
+            ErrorHandler.handleError(HttpStatus.UNPROCESSABLE_ENTITY, 'Import file is required')
+        }
+        ExportModel importModel = params.importFile.inputStream.withCloseable {InputStream inputStream ->
+            objectMapper.readValue(inputStream, ExportModel)
+        }
+        log.info '*** imported JSON model in {} ms ***', (System.nanoTime() - start).intdiv(1000000L)
         if (!importModel.terminology){
             ErrorHandler.handleError(HttpStatus.BAD_REQUEST, 'Cannot import JSON as terminology/ies is not present')
         }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/cache/ModelCacheableRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/cache/ModelCacheableRepository.groovy
@@ -68,6 +68,11 @@ class ModelCacheableRepository<M extends Model> extends AdministeredItemCacheabl
         repository.readByLabelAndModelVersion(label, modelVersion)
     }
 
+    @Override
+    M readByLabelAndModelVersionIsNull(String label) {
+        repository.readByLabelAndModelVersionIsNull(label)
+    }
+
     List<M> findAllByParentAndPathIdentifier(UUID item, String pathIdentifier) {
         repository.findAllByParentAndPathIdentifier(item,  pathIdentifier)
     }

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/model/ModelRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/model/ModelRepository.groovy
@@ -39,6 +39,9 @@ trait ModelRepository<M extends Model> implements AdministeredItemRepository<M> 
     @Nullable
     abstract M readByLabelAndModelVersion(String label, ModelVersion modelVersion)
 
+    @Nullable
+    abstract M readByLabelAndModelVersionIsNull(String label)
+
     abstract Boolean handles(String domainType)
 
 


### PR DESCRIPTION

Move importer upload handling away from byte arrays and towards streams

Imports bind the small import parameters payload separately from the uploaded file

Uses StreamingFileUpload for the file part; uploads can be consumed
without waiting for CompletedFileUpload.

However, FileParameter is backward-compatible for byte-array style callers

Update tests and client helpers to send 'importParameters' as the
first multipart section.