### PR TITLE
Label and path prefix case handling

### DIFF
--- a/mauro-api/src/main/groovy/org/maurodata/service/path/PathPrefixTypeLookup.groovy
+++ b/mauro-api/src/main/groovy/org/maurodata/service/path/PathPrefixTypeLookup.groovy
@@ -7,6 +7,8 @@ import org.maurodata.domain.folder.Folder
 import org.maurodata.domain.model.AdministeredItem
 import org.maurodata.persistence.cache.AdministeredItemCacheableRepository
 
+import java.util.Locale
+
 @CompileStatic
 @Slf4j
 class PathPrefixTypeLookup {
@@ -27,15 +29,19 @@ class PathPrefixTypeLookup {
         administeredItemRepositories.each {
             AdministeredItem domainClass = (AdministeredItem) it.domainClass.getDeclaredConstructor().newInstance()
 
-            lookup.putIfAbsent(domainClass.getPathPrefix(), domainClass.getDomainType())
+            lookup.putIfAbsent(normalisePathPrefix(domainClass.getPathPrefix()), domainClass.getDomainType())
         }
         //special case ->VersionedFolder = folder with isVersionable() set.
-        lookup.put('vf', Folder.class.simpleName)
+        lookup.put(normalisePathPrefix('vf'), Folder.class.simpleName)
         pathPrefixDomainType = lookup.asImmutable()
 
     }
 
     String getDomainType(String pathPrefix) {
-        pathPrefixDomainType.getOrDefault(pathPrefix, null)
+        pathPrefixDomainType.getOrDefault(normalisePathPrefix(pathPrefix), null)
+    }
+
+    private static String normalisePathPrefix(String pathPrefix) {
+        pathPrefix?.toLowerCase(Locale.ROOT)
     }
 }

--- a/mauro-api/src/test/groovy/org/maurodata/path/PathControllerIntegrationSpec.groovy
+++ b/mauro-api/src/test/groovy/org/maurodata/path/PathControllerIntegrationSpec.groovy
@@ -54,6 +54,38 @@ class PathControllerIntegrationSpec extends CommonDataSpec {
         domainType | path
         'codeSet'  | EXPECTED_PATH
         'codesets' | EXPECTED_PATH
+        'CODESET'  | EXPECTED_PATH
+        'CoDeSeTs' | EXPECTED_PATH
+        'codeSet'  | 'FO:Test folder|CS:test label$main'
+        'CODESET'  | 'Fo:Test folder|Cs:test label$main'
+    }
+
+    void 'test getResource by path -label case differs -shouldThrowException'() {
+        when:
+        pathApi.getResourceByPath('codeSet', 'fo:Test folder|cs:Test Label$main')
+
+        then:
+        HttpStatusException exception = thrown()
+        exception.status == HttpStatus.NOT_FOUND
+    }
+
+    void 'test getResource by path -labels differing only by case are distinct'() {
+        given:
+        CodeSet upperCaseCodeSet = codeSetApi.create(folderId, codeSet(EXPECTED_LABEL.toUpperCase()))
+
+        when:
+        CodeSet lowerCaseCodeSet = pathApi.getResourceByPath('codeSet', EXPECTED_PATH) as AdministeredItem as CodeSet
+
+        then:
+        lowerCaseCodeSet.id == codeSetId
+        lowerCaseCodeSet.label == EXPECTED_LABEL
+
+        when:
+        CodeSet retrievedUpperCaseCodeSet = pathApi.getResourceByPath('codeSet', 'fo:Test folder|cs:TEST LABEL$main') as AdministeredItem as CodeSet
+
+        then:
+        retrievedUpperCaseCodeSet.id == upperCaseCodeSet.id
+        retrievedUpperCaseCodeSet.label == EXPECTED_LABEL.toUpperCase()
     }
 
 
@@ -183,4 +215,3 @@ class PathControllerIntegrationSpec extends CommonDataSpec {
 
     }
 }
-

--- a/mauro-api/src/test/groovy/org/maurodata/service/path/PathPrefixTypeLookupTest.groovy
+++ b/mauro-api/src/test/groovy/org/maurodata/service/path/PathPrefixTypeLookupTest.groovy
@@ -58,7 +58,12 @@ class PathPrefixTypeLookupTest extends Specification {
         'ev'       | EnumerationValue.class.simpleName
         'csc'      | ClassificationScheme.class.simpleName
         'cl'       | Classifier.class.simpleName
+        'FO'       | Folder.class.simpleName
+        'vF'       | Folder.class.simpleName
+        'DM'       | DataModel.class.simpleName
+        'dC'       | DataClass.class.simpleName
+        'DCC'      | DataClassComponent.class.simpleName
+        'CSC'      | ClassificationScheme.class.simpleName
     }
 }
-
 

--- a/mauro-domain/src/main/groovy/org/maurodata/domain/model/Path.groovy
+++ b/mauro-domain/src/main/groovy/org/maurodata/domain/model/Path.groovy
@@ -119,7 +119,7 @@ class Path {
         for (from = 0; from < nodes.size(); from++) {
             final PathNode node = nodes.get(from)
 
-            if (node.prefix == toMatch.prefix && node.identifier == toMatch.identifier) {break}
+            if (node.prefix?.equalsIgnoreCase(toMatch.prefix) && node.identifier == toMatch.identifier) {break}
         }
         for (int copy = from; copy < nodes.size(); copy++) {
             lessNodes.add(nodes.get(copy))
@@ -161,7 +161,7 @@ class Path {
     PathNode findLastPathNodeByPrefix(final String prefix) {
         for (int p = nodes.size() - 1; p >= 0; p--) {
             final PathNode pathNode = nodes.get(p)
-            if (pathNode.prefix == prefix) {return pathNode}
+            if (pathNode.prefix?.equalsIgnoreCase(prefix)) {return pathNode}
         }
         return null
     }
@@ -176,7 +176,7 @@ class Path {
     String getModelIdentifier() {
         for (int p = 0, n = nodes.size(); p < n; p++) {
             final PathNode pathNode = nodes.get(p)
-            if (!PathNode.canHaveModelIdentifier.contains(pathNode.prefix)) {continue}
+            if (!PathNode.canHaveModelIdentifier(pathNode.prefix)) {continue}
             if (pathNode.modelIdentifier) {return pathNode.modelIdentifier}
         }
         return null
@@ -186,7 +186,7 @@ class Path {
         nodes.each {PathNode pathNode -> pathNode.modelIdentifier = null}
         for (int p = 0, n = nodes.size(); p < n; p++) {
             final PathNode pathNode = nodes.get(p)
-            if (!PathNode.canHaveModelIdentifier.contains(pathNode.prefix)) {continue}
+            if (!PathNode.canHaveModelIdentifier(pathNode.prefix)) {continue}
             pathNode.modelIdentifier = modelIdentifier
             break
         }
@@ -227,6 +227,10 @@ class Path {
         }
 
         static List<String> canHaveModelIdentifier = ['dm','vf','csc','cs','te']
+
+        static boolean canHaveModelIdentifier(final String prefix) {
+            canHaveModelIdentifier.any {it.equalsIgnoreCase(prefix)}
+        }
 
         static PathNode from(String str) {
             Pattern nodePattern = ~/^(?<prefix>\w{2,3}):(?<identifier>(?:%[$@|:%]|[^@$|:%])*?)(?:\$(?<modelIdentifier>(?:%[$@|:%]|[^@$|:%])*))?(?:@(?<attribute>(?:%[$@|:%]|[^@$|:%])*))?$/

--- a/mauro-domain/src/test/groovy/org/maurodata/test/domain/model/PathMethodsTest.groovy
+++ b/mauro-domain/src/test/groovy/org/maurodata/test/domain/model/PathMethodsTest.groovy
@@ -29,6 +29,8 @@ class PathMethodsTest extends Specification {
         'fo'       | "fo:soluta eum architecto|te:Dewey Decimal Classification v22\$main"                           | "soluta eum architecto"
         'te'       | "fo:soluta eum architecto|te:Dewey Decimal Classification v22\$main"                           | "Dewey Decimal Classification v22"
         'dc'       | "fo:soluta eum architecto|dm:modi unde est\$1.0.0|dc:est quasi vel|dc:est sed hic"              | "est sed hic"
+        'DE'       | "fo:soluta eum architecto|dm:modi unde est\$matrix|dc:est quasi vel|de:new data element label" | "new data element label"
+        'dm'       | "FO:soluta eum architecto|DM:modi unde est\$matrix|DC:est quasi vel|DE:new data element label" | "modi unde est"
     }
 
     @Unroll
@@ -46,6 +48,35 @@ class PathMethodsTest extends Specification {
         'fo:soluta eum architecto'                                                                          | null
         'fo:soluta eum architecto|te:Dewey Decimal Classification v22$main'                                 | "main"
         'fo:soluta eum architecto|vf:versionio de folder$main|te:Dewey Decimal Classification v22$main'     | "main"
+        'FO:soluta eum architecto|DM:modi unde est$matrix|DC:est quasi vel|DE:new data element label$2.0.0' | "matrix"
+        'VF:versionio de folder$main|TE:Dewey Decimal Classification v22'                                   | "main"
+    }
+
+    @Unroll
+    void 'test trimUntil keeps identifiers case sensitive and prefixes case insensitive for #pathRoot'() {
+        when:
+        Path trimmedPath = new Path(fullPath).trimUntil(pathRoot)
+
+        then:
+        trimmedPath.toString() == expectedPath
+
+        where:
+        fullPath                                                                                       | pathRoot              | expectedPath
+        'FO:Folder|DM:Model$main|DC:Name|DE:Element'                                                   | 'dm:Model$main'       | 'DM:Model$main|DC:Name|DE:Element'
+        'FO:Folder|DM:Model$main|DC:Name|DE:Element'                                                   | 'dm:model$main'       | ''
+        'fo:Folder|dm:Model$main|dc:Name|de:Element'                                                   | 'DM:Model$main'       | 'dm:Model$main|dc:Name|de:Element'
+        'fo:Folder|dm:Model$main|dc:Name|de:Element'                                                   | 'DM:model$main'       | ''
+    }
+
+    void 'test set modelIdentifier recognises mixed case model prefixes'() {
+        given:
+        Path path = new Path('FO:Folder|DM:Model|DC:Name')
+
+        when:
+        path.modelIdentifier = 'main'
+
+        then:
+        path.toString() == 'FO:Folder|DM:Model$main|DC:Name'
     }
 
     void 'test getting path from string'() {
@@ -65,6 +96,7 @@ class PathMethodsTest extends Specification {
         "vf:soluta eum architecto\$main|te:Dewey Decimal Classification v22"                            | 2             | 0
         "fo:soluta eum architecto|te:Dewey Decimal Classification v22"                                  | 2             | -1
         "fo:soluta eum architecto|dm:modi unde est\$1.0.0|dc:est quasi vel|dc:est sed hic"              | 4             | 1
+        "FO:soluta eum architecto|DM:modi unde est\$matrix|DC:est quasi vel|DE:new data element label"  | 4             | 1
 
     }
 

--- a/mauro-domain/src/test/groovy/org/maurodata/test/domain/model/PathTest.groovy
+++ b/mauro-domain/src/test/groovy/org/maurodata/test/domain/model/PathTest.groovy
@@ -29,6 +29,7 @@ class PathTest extends Specification {
         'vf:My%$versioned%%%|folder|dm:data%|model|de:data%|element@attribute' | 3
         'vf:My%$versioned%%%|folder|dm:data%|model|de:data%|element%@home@attribute' | 3
         'vf:My%$versioned%%%|folder%:%:|dm:data%|model|de:data%|element%@home@attribute' | 3
+        'VF:versioned folder$main|DM:Data Model|DE:Data Element' | 3
     }
 
     @Unroll
@@ -51,6 +52,17 @@ class PathTest extends Specification {
         'vf:My%$versioned%%%|folder|dm:data%|model|de:data%|element@attribute' | ''
         'vf:My%$versioned%%%|folder|dm:data%|model|de:data%|element%@home@attribute' | ''
         'vf:My%$versioned%%%|folder%:|dm:data%|model|de:data%|element%@home@attribute' | ''
+        'VF:versioned folder$main|DM:Data Model|DE:Data Element' | ''
+    }
+
+    void 'test path node identifiers are case sensitive'() {
+        when:
+        Path.PathNode upperCaseIdentifier = Path.PathNode.from('dc:Name')
+        Path.PathNode lowerCaseIdentifier = Path.PathNode.from('dc:name')
+
+        then:
+        upperCaseIdentifier.prefix == lowerCaseIdentifier.prefix
+        upperCaseIdentifier.identifier != lowerCaseIdentifier.identifier
     }
 
     @Unroll

--- a/mauro-persistence/src/main/groovy/org/maurodata/persistence/dataflow/DataClassComponentRepository.groovy
+++ b/mauro-persistence/src/main/groovy/org/maurodata/persistence/dataflow/DataClassComponentRepository.groovy
@@ -126,7 +126,6 @@ abstract class DataClassComponentRepository implements ModelItemRepository<DataC
     abstract Long removeTargetDataClasses(@NonNull UUID id)
 
     Boolean handlesPathPrefix(final String pathPrefix) {
-        'dsc'.equalsIgnoreCase(pathPrefix)
+        'dcc'.equalsIgnoreCase(pathPrefix)
     }
 }
-


### PR DESCRIPTION
Ensure path prefixes are handled case-insensitively when parsing, matching,
trimming, resolving model identifiers, and mapping prefixes to domain types.

Keep labels and path identifiers case-sensitive, and add coverage proving that
items whose labels differ only by case remain distinct.

Correct the DataClassComponent path prefix handler from dsc to dcc.

Add tests for:
- mixed-case path prefixes in Path methods
- PathPrefixTypeLookup mixed-case prefix resolution
- API path lookup with mixed-case prefixes and domain types
- label/path identifier case sensitivity