### PR TITLE
Add import tests for classification schemes and classifiers

### DIFF
--- a/mauro-api/src/test/groovy/org/maurodata/importexport/DataModelJsonImportExportIntegrationSpec.groovy
+++ b/mauro-api/src/test/groovy/org/maurodata/importexport/DataModelJsonImportExportIntegrationSpec.groovy
@@ -6,6 +6,8 @@ import io.micronaut.http.HttpResponse
 import io.micronaut.http.MediaType
 import io.micronaut.http.client.multipart.MultipartBody
 import jakarta.inject.Singleton
+import org.maurodata.domain.classifier.ClassificationScheme
+import org.maurodata.domain.classifier.Classifier
 import org.maurodata.domain.datamodel.DataModel
 import org.maurodata.domain.datamodel.DataType
 import org.maurodata.domain.facet.Annotation
@@ -143,6 +145,47 @@ class DataModelJsonImportExportIntegrationSpec extends CommonDataSpec {
         importedDataTypes
         importedDataTypes.count == 1
         importedDataTypes.items.domainType.first() == dataType.domainType
+    }
+
+    void 'test consume export data model with existing classifier - should import and attach classifier'() {
+        given:
+        ClassificationScheme classificationScheme =
+            classificationSchemeApi.create(folderId, new ClassificationScheme(label: 'Classification scheme for data model import'))
+        Classifier classifier =
+            classifierApi.create(classificationScheme.id, new Classifier(label: 'Classifier for data model import'))
+        classifierApi.createAdministeredItemClassifier('dataModel', dataModelId, classifier.id)
+
+        and:
+        HttpResponse<byte[]> response = dataModelApi.exportModel(dataModelId, 'org.maurodata.plugin.exporter.json', 'JsonDataModelExporterPlugin', '4.0.0')
+        Map parsedJson = jsonSlurper.parseText(new String(response.body())) as Map
+
+        expect:
+        parsedJson.dataModel.classifiers.id == List.of(classifier.id.toString())
+
+        when:
+        MultipartBody importRequest = MultipartBody.builder()
+            .addPart('folderId', folderId.toString())
+            .addPart('importFile', 'file.json', MediaType.APPLICATION_JSON_TYPE, response.body())
+            .build()
+        ListResponse<DataModel> dataModelResponse = dataModelApi.importModel(importRequest, 'org.maurodata.plugin.importer.json', 'JsonDataModelImporterPlugin', '4.0.0')
+        UUID importedDataModelId = dataModelResponse.items.first().id
+
+        then:
+        importedDataModelId != dataModelId
+
+        when:
+        DataModel importedDataModel = dataModelApi.show(importedDataModelId)
+
+        then:
+        importedDataModel.classifiers.size() == 1
+        importedDataModel.classifiers.first().id == classifier.id
+
+        when:
+        Classifier joinedClassifier = classifierApi.getAdministeredItemClassifier('dataModel', importedDataModelId, classifier.id)
+
+        then:
+        joinedClassifier
+        joinedClassifier.id == classifier.id
     }
 
     // TODO: Is this used, or could it be?

--- a/mauro-api/src/test/groovy/org/maurodata/importexport/FolderJsonImportExportIntegrationSpec.groovy
+++ b/mauro-api/src/test/groovy/org/maurodata/importexport/FolderJsonImportExportIntegrationSpec.groovy
@@ -1,5 +1,7 @@
 package org.maurodata.importexport
 
+import org.maurodata.domain.classifier.ClassificationScheme
+import org.maurodata.domain.classifier.Classifier
 import org.maurodata.domain.datamodel.DataClass
 import org.maurodata.domain.datamodel.DataModel
 import org.maurodata.domain.datamodel.DataType
@@ -29,7 +31,8 @@ import spock.lang.Shared
 @Singleton
 @Sql(scripts = ["classpath:sql/tear-down-annotation.sql", "classpath:sql/tear-down-metadata.sql",
         "classpath:sql/tear-down-summary-metadata.sql", "classpath:sql/tear-down-datamodel.sql",
-        "classpath:sql/tear-down.sql", "classpath:sql/tear-down-folder.sql"], phase = Sql.Phase.AFTER_EACH)
+        "classpath:sql/tear-down-classifiers.sql", "classpath:sql/tear-down.sql",
+        "classpath:sql/tear-down-folder.sql"], phase = Sql.Phase.AFTER_EACH)
 class FolderJsonImportExportIntegrationSpec extends CommonDataSpec {
 
     @Shared
@@ -327,6 +330,57 @@ class FolderJsonImportExportIntegrationSpec extends CommonDataSpec {
         importedTermRelationship.items[0].sourceTerm.code == 'source code'
         importedTermRelationship.items[0].targetTerm.code == 'target code'
         importedTermRelationship.items[0].relationshipType.id == importedTermRelationshipTypeId
+    }
+
+    void 'test consume export folder with classification scheme - should preserve classification scheme and classifier ids'() {
+        given:
+        ClassificationScheme classificationScheme =
+            classificationSchemeApi.create(folderId, new ClassificationScheme(label: 'Classification scheme to preserve'))
+        Classifier classifier =
+            classifierApi.create(classificationScheme.id, new Classifier(label: 'Classifier to preserve'))
+        Classifier childClassifier =
+            classifierApi.create(classificationScheme.id, classifier.id, new Classifier(label: 'Child classifier to preserve'))
+
+        and:
+        HttpResponse<byte[]> exportResponse = folderApi.exportModel(folderId, 'org.maurodata.plugin.exporter.json', 'JsonFolderExporterPlugin', '4.0.0')
+        ExportModel export = objectMapper.readValue(exportResponse.body(), ExportModel)
+
+        expect:
+        export.folder.classificationSchemes.size() == 1
+        export.folder.classificationSchemes.first().id == classificationScheme.id
+        export.folder.classificationSchemes.first().csClassifiers.id.toSet() == [classifier.id, childClassifier.id].toSet()
+
+        when:
+        classificationSchemeApi.delete(classificationScheme.id, new ClassificationScheme(), true)
+
+        then:
+        classificationSchemeApi.list(folderId).items.isEmpty()
+        classifierApi.listAllClassifiers().items.isEmpty()
+
+        when:
+        MultipartBody importRequest = MultipartBody.builder()
+            .addPart('folderId', folderId.toString())
+            .addPart('importFile', 'file.json', MediaType.APPLICATION_JSON_TYPE, objectMapper.writeValueAsBytes(export))
+            .build()
+        ListResponse<Folder> response = folderApi.importModel(importRequest, 'org.maurodata.plugin.importer.json', 'JsonFolderImporterPlugin', '4.0.0')
+        UUID importedFolderId = response.items.first().id
+
+        then:
+        response.count == 1
+        importedFolderId
+
+        when:
+        ListResponse<ClassificationScheme> importedClassificationSchemes = classificationSchemeApi.list(importedFolderId)
+
+        then:
+        importedClassificationSchemes.count == 1
+        importedClassificationSchemes.items.first().id == classificationScheme.id
+
+        when:
+        ListResponse<Classifier> importedClassifiers = classifierApi.list(classificationScheme.id)
+
+        then:
+        importedClassifiers.items.id.toSet() == [classifier.id, childClassifier.id].toSet()
     }
 
 


### PR DESCRIPTION
- Verify folder JSON import preserves ClassificationScheme and Classifier ids.
- Verify data model JSON import reattaches existing classifier associations.